### PR TITLE
feat: add A/B I/O contracts (schema + fixtures) ref #4

### DIFF
--- a/contracts/alert_blockkit.md
+++ b/contracts/alert_blockkit.md
@@ -1,0 +1,58 @@
+# LambdaA(app_inspect) 出力仕様：private通知（Block Kit）
+
+## 目的
+違反（または要確認）と判定した投稿を、運営用 private チャンネルへ通知する。
+通知には「承認ボタン」を含め、押下時に LambdaB(app_alert) がスレッド返信を実行する。
+
+---
+
+## 通知先
+- private channel ID は環境変数等で指定（例: `ALERT_PRIVATE_CHANNEL_ID`）
+
+---
+
+## ボタン仕様（A -> B 契約）
+### action_id（固定）
+- `approve_violation`
+
+### value（固定：JSON文字列）
+- `lambda/contracts/alert_button_value.schema.json` に準拠
+- 最低限 MUST:
+  - `trace_id`
+  - `origin_channel`
+  - `origin_ts`
+
+---
+
+## Block Kit 例（Slack API: chat.postMessage）
+> blocks の中身は実装側で変更可。ただし **action_id/value** は固定。
+
+```json
+{
+  "text": "🚨 違反の可能性がある投稿を検出しました",
+  "blocks": [
+    {
+      "type": "section",
+      "text": { "type": "mrkdwn", "text": "🚨 *違反の可能性がある投稿を検出しました* \n・理由: `spam` \n・trace_id: `slack:EvXXXX`" }
+    },
+    {
+      "type": "context",
+      "elements": [
+        { "type": "mrkdwn", "text": "origin_channel: `C123` / origin_ts: `1700000000.12345`" }
+      ]
+    },
+    { "type": "divider" },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "削除勧告を送る", "emoji": true },
+          "style": "danger",
+          "action_id": "approve_violation",
+          "value": "{\"version\":\"v1\",\"trace_id\":\"slack:EvXXXX\",\"origin_channel\":\"C123\",\"origin_ts\":\"1700000000.12345\",\"reason\":\"spam\",\"policy_refs\":[\"p3-2\"]}"
+        }
+      ]
+    }
+  ]
+}

--- a/contracts/alert_button_value.schema.json
+++ b/contracts/alert_button_value.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "alert_button_value.schema.json",
+  "title": "Slack Alert Button Value (A -> B contract)",
+  "type": "object",
+  "required": ["trace_id", "origin_channel", "origin_ts"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Contract version string, e.g. 'v1'"
+    },
+    "trace_id": {
+      "type": "string",
+      "description": "E1 trace id. LambdaB must reuse this for logs."
+    },
+    "origin_channel": {
+      "type": "string",
+      "description": "Channel ID of the original (violating) post."
+    },
+    "origin_ts": {
+      "type": "string",
+      "description": "Message ts of the original (violating) post."
+    },
+    "origin_user": {
+      "type": "string",
+      "description": "User ID of the original poster (optional)."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Short reason label for violation (optional)."
+    },
+    "policy_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Policy / guideline references (optional)."
+    },
+    "detected_at": {
+      "type": "string",
+      "description": "ISO timestamp when detected (optional)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/fixtures/alert_button_value.json
+++ b/contracts/fixtures/alert_button_value.json
@@ -1,0 +1,8 @@
+{
+  "version": "v1",
+  "trace_id": "slack:Ev_TEST_0001",
+  "origin_channel": "C_ORIGIN",
+  "origin_ts": "1700000000.12345",
+  "reason": "spam",
+  "policy_refs": ["p3-2"]
+}

--- a/contracts/fixtures/event_api_message.json
+++ b/contracts/fixtures/event_api_message.json
@@ -1,0 +1,7 @@
+{
+  "headers": {
+    "content-type": "application/json"
+  },
+  "isBase64Encoded": false,
+  "body": "{\"type\":\"event_callback\",\"team_id\":\"T_TEST\",\"event_id\":\"Ev_TEST_0001\",\"event\":{\"type\":\"message\",\"channel\":\"C_ORIGIN\",\"ts\":\"1700000000.12345\",\"text\":\"これはテスト投稿です\"}}"
+}

--- a/contracts/fixtures/interactivity_button_click.json
+++ b/contracts/fixtures/interactivity_button_click.json
@@ -1,0 +1,11 @@
+{
+  "team": { "id": "T_TEST" },
+  "channel": { "id": "C_PRIVATE" },
+  "message": { "ts": "1700000001.00001" },
+  "actions": [
+    {
+      "action_id": "approve_violation",
+      "value": "{\"version\":\"v1\",\"trace_id\":\"slack:Ev_TEST_0001\",\"origin_channel\":\"C_ORIGIN\",\"origin_ts\":\"1700000000.12345\",\"reason\":\"spam\",\"policy_refs\":[\"p3-2\"]}"
+    }
+  ]
+}

--- a/contracts/lambdaA_input_event.md
+++ b/contracts/lambdaA_input_event.md
@@ -1,0 +1,49 @@
+# LambdaA(app_inspect) 入力仕様（Slack Event API）
+
+## 目的
+Slack投稿（Event API）を受け取って「検出→private通知（ボタン付き）」を行う。
+
+## 入口（想定）
+API Gateway 経由で LambdaA が受信する。
+- Content-Type: application/json
+- body: Slack Event API のJSON文字列（APIGW proxy形式）
+
+> ローカル/テストでは、Slack JSON本体のみを直接 handler に渡してもよい。
+
+---
+
+## 入力（Slack Event API body）
+### 対象
+- `type = "event_callback"`（通常イベント）
+- `event.type = "message"`（最低限メッセージ投稿）
+
+### 必須フィールド（MUST）
+- `team_id` : string
+- `event_id` : string（冪等キーとして利用）
+- `event.channel` : string（投稿チャンネルID）
+- `event.ts` : string（メッセージts）
+- `event.text` : string（本文。空の場合あり得る）
+
+### 任意フィールド（MAY）
+- `event.user` : string（投稿者ID）
+- `event.thread_ts` : string（スレッド内投稿なら）
+- `event.subtype` : string（bot_message等の判別に使用）
+
+---
+
+## 冪等（重複イベント）方針
+- Slackはリトライ等で同一イベントを複数回送る可能性がある。
+- 原則 `event_id` を冪等キーとして扱う。
+  - ただし冪等実装（DynamoDB等）は別タスクで、当面はログで検知してもよい。
+
+---
+
+## trace_id（E1と整合）
+- trace_id は原則 `trace_id = "slack:<event_id>"` とする。
+- private通知のボタン `value(JSON)` に trace_id を必ず含め、LambdaBが引き継ぐ。
+
+---
+
+## URL Verification（参考）
+Slack App設定直後の検証リクエスト `type="url_verification"` は、
+本仕様の検出対象外（別ハンドリング/別issue）としてよい。

--- a/contracts/lambdaB_input_interactivity.md
+++ b/contracts/lambdaB_input_interactivity.md
@@ -1,0 +1,41 @@
+
+# LambdaB(app_alert) 入力仕様（Slack Interactivity）
+
+## 目的
+private通知の「承認ボタン」押下を受け取り、元投稿（違反投稿）へスレッド返信で削除勧告を行う。
+
+---
+
+## 入口（想定）
+API Gateway 経由で Slack から送られる Interactivity を受信。
+- Content-Type: application/x-www-form-urlencoded
+- body: `payload=<JSON>`（payloadにSlack interactivity JSONが入る）
+
+> ユニットテストでは、payload JSON本体（辞書）を直接渡してよい（fixture参照）。
+
+---
+
+## 処理対象のボタン
+- `actions[0].action_id == "approve_violation"` のときのみ処理する
+- それ以外は no-op（200返却）またはログのみ（方針は実装側）
+
+---
+
+## 必須（MUST）
+`actions[0].value` を JSON としてパースし、以下を取得する：
+- `trace_id`
+- `origin_channel`
+- `origin_ts`
+
+value(JSON)の仕様は `lambda/contracts/alert_button_value.schema.json` に準拠。
+
+---
+
+## 出力（Slackへ）
+- `origin_channel` の `origin_ts` に対し、スレッド返信（thread_ts=origin_ts）で勧告テンプレ投稿。
+
+---
+
+## trace_id（E1と整合）
+- LambdaB のログは、valueの `trace_id` を引き継ぐ（build_contextで抽出）。
+- これにより A→B を CloudWatch 上で追跡可能にする。


### PR DESCRIPTION
Closes #4

## 変更内容
- LambdaA(app_inspect) / LambdaB(app_alert) の入出力(I/F)契約を追加
- action_id と button value(JSON) の仕様を固定（schema化）
- fixtures（Slack Event / Interactivity / button value）を追加
- 契約ドキュメント（md）を追加

## 目的
- A/Bを並行開発できるように、境界（契約）を先に固定するため
- BはA未完成でも fixtures を使って実装・単体テスト可能にするため

## 影響範囲
- 実行コード変更なし（contracts/fixtures の追加のみ）
- インフラ変更なし

## 確認方法
- contracts/*.mdをレビューして仕様合意できること
- fixtures/*.json が仕様どおりの形になっていること

