### PR TITLE
feat: 3段階違反検出ロジック + リトライヘッダーチェック

### DIFF
--- a/lambda/app_inspect/handler.py
+++ b/lambda/app_inspect/handler.py
@@ -21,6 +21,13 @@ def lambda_handler(event: dict, context: Any) -> dict:
     log_info(ctx, action="request_received")
 
     try:
+        # 1.5 Slackリトライ検出（3秒タイムアウト時の再送を即返却）
+        raw_headers = event.get("headers") or {}
+        lower_headers = {k.lower(): v for k, v in raw_headers.items()}
+        if lower_headers.get("x-slack-retry-num"):
+            log_info(ctx, action="retry_skip", retry_num=lower_headers["x-slack-retry-num"])
+            return {"statusCode": 200, "body": "ok"}
+
         # 設定のロード
         cfg = load_config()
 

--- a/lambda/app_inspect/services/data/articles.json
+++ b/lambda/app_inspect/services/data/articles.json
@@ -1,0 +1,235 @@
+{
+  "metadata": {
+    "description": "違反検出用の重要条文リスト",
+    "source": "松尾・岩澤研究室の各種規約から禁止事項を抽出",
+    "regulations": [
+      "AI Community参加規約",
+      "教育コンテンツ利用規約",
+      "講座受講規約",
+      "講座受講用アカウント登録規約"
+    ],
+    "updated": "2026-02-14"
+  },
+  "articles": [
+    {
+      "id": "11-i",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(i)",
+      "category": "法令違反",
+      "content": "法令または公序良俗に違反する行為",
+      "keywords": ["違法", "犯罪", "公序良俗"],
+      "examples": ["違法ダウンロード", "詐欺", "差別発言"]
+    },
+    {
+      "id": "11-ii",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(ii)",
+      "category": "犯罪関連",
+      "content": "犯罪行為に関連する行為",
+      "keywords": ["犯罪", "違法"],
+      "examples": ["ハッキング方法の共有", "詐欺への誘導"]
+    },
+    {
+      "id": "11-iii",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(iii)",
+      "category": "システム妨害",
+      "content": "当研究室、他のユーザー、または第三者のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為",
+      "keywords": ["サーバー", "ネットワーク", "妨害", "攻撃"],
+      "examples": ["DDoS攻撃", "サーバー負荷攻撃"]
+    },
+    {
+      "id": "11-iv",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(iv)",
+      "category": "SNS共有禁止",
+      "content": "slack上でのやり取りやスクリーンショットを、SNS上にアップするといった行為",
+      "keywords": ["SNS", "Twitter", "X", "インスタ", "Facebook", "スクショ", "スクリーンショット", "アップ", "投稿", "載せる"],
+      "examples": ["このスレッド面白いからTwitterに載せよう", "Slack晒してやる"]
+    },
+    {
+      "id": "11-v",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(v)",
+      "category": "勧誘行為",
+      "content": "ネットワークビジネス、宗教等の勧誘行為",
+      "keywords": ["勧誘", "ネットワークビジネス", "MLM", "宗教", "副業", "稼げる", "儲かる", "投資"],
+      "examples": ["副業で稼げる方法教えます、DM待ってます", "簡単に儲かる投資案件あります"]
+    },
+    {
+      "id": "11-vi",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(vi)",
+      "category": "録画共有禁止",
+      "content": "講義の録画を無断で共有する行為",
+      "keywords": ["録画", "共有", "シェア", "Zoom", "動画", "配布"],
+      "examples": ["Zoomの録画共有します！", "講義動画持ってる人いますか？"]
+    },
+    {
+      "id": "11-vii",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(vii)",
+      "category": "運営妨害",
+      "content": "当研究室のサービスの運営を妨害するおそれのある行為",
+      "keywords": ["妨害", "荒らし", "スパム"],
+      "examples": ["運営批判の連続投稿", "大量のスパムメッセージ"]
+    },
+    {
+      "id": "11-viii",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(viii)",
+      "category": "不正アクセス",
+      "content": "不正アクセスをし、またはこれを試みる行為",
+      "keywords": ["不正アクセス", "ハッキング", "クラッキング"],
+      "examples": ["管理者権限の不正取得", "他人のアカウントへのログイン試行"]
+    },
+    {
+      "id": "11-ix",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(ix)",
+      "category": "個人情報収集",
+      "content": "他のユーザーに関する個人情報等を収集または蓄積する行為",
+      "keywords": ["個人情報", "収集", "蓄積", "連絡先", "住所", "電話番号"],
+      "examples": ["参加者の連絡先リスト作りました", "皆さんの本名教えてください"]
+    },
+    {
+      "id": "11-x",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(x)",
+      "category": "不正利用",
+      "content": "不正な目的を持って本サービスを利用する行為",
+      "keywords": ["不正", "悪用"],
+      "examples": ["競合他社のスパイ活動", "講座内容の転売目的"]
+    },
+    {
+      "id": "11-xi",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(xi)",
+      "category": "迷惑行為",
+      "content": "本サービスの他のユーザーまたはその他の第三者に不利益、損害、不快感を与える行為",
+      "keywords": ["迷惑", "不快", "嫌がらせ", "ハラスメント", "誹謗中傷"],
+      "examples": ["人格攻撃", "しつこい嫌がらせ", "差別的発言"]
+    },
+    {
+      "id": "11-xii",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(xii)",
+      "category": "なりすまし",
+      "content": "他のユーザーに成りすます行為",
+      "keywords": ["なりすまし", "偽装", "詐称"],
+      "examples": ["メンターを装った投稿", "運営スタッフのふりをする"]
+    },
+    {
+      "id": "11-xiii",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(xiii)",
+      "category": "無許可宣伝",
+      "content": "当研究室が許諾しない本サービス上での宣伝、広告、勧誘、または営業行為",
+      "keywords": ["宣伝", "広告", "営業", "PR", "アフィリエイト"],
+      "examples": ["自社サービスの宣伝", "アフィリエイトリンクの共有"]
+    },
+    {
+      "id": "11-xiv",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(xiv)",
+      "category": "出会い目的",
+      "content": "面識のない異性との出会いを目的とした行為",
+      "keywords": ["出会い", "デート", "恋愛"],
+      "examples": ["彼女募集中です", "飲みに行きませんか？（異性限定）"]
+    },
+    {
+      "id": "11-xv",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(xv)",
+      "category": "反社関連",
+      "content": "当研究室のサービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為",
+      "keywords": ["反社", "暴力団"],
+      "examples": []
+    },
+    {
+      "id": "11-xvi",
+      "regulation": "AI Community参加規約",
+      "article": "AI Community参加規約 第11条(xvi)",
+      "category": "その他不適切",
+      "content": "その他、当研究室が不適切と判断する行為",
+      "keywords": [],
+      "examples": []
+    },
+    {
+      "id": "edu-6",
+      "regulation": "教育コンテンツ利用規約",
+      "article": "教育コンテンツ利用規約 第6条",
+      "category": "コンテンツ無断配布",
+      "content": "本教育コンテンツを第三者への提供・譲渡・貸与・公開・複製・頒布・翻案等をしてはなりません",
+      "keywords": ["資料", "教材", "コンテンツ", "共有", "配布", "メルカリ", "ヤフオク", "転売", "売る"],
+      "examples": ["この講座の資料、メルカリで売ったら儲かりそうw", "教材PDFあげます"]
+    },
+    {
+      "id": "edu-8-iii",
+      "regulation": "教育コンテンツ利用規約",
+      "article": "教育コンテンツ利用規約 第8条(iii)",
+      "category": "コンテンツ営利利用",
+      "content": "本教育コンテンツを営利目的で使用する行為",
+      "keywords": ["営利", "商用", "ビジネス", "転売", "販売", "有料", "セミナー", "売る"],
+      "examples": ["講座の内容で有料セミナーやります", "教材を転売して稼ごう"]
+    },
+    {
+      "id": "course-6",
+      "regulation": "講座受講規約",
+      "article": "講座受講規約 第6条",
+      "category": "録画・スクショ禁止",
+      "content": "ユーザーは、講座の録画・スクリーンショットを無断で行い、第三者に共有してはなりません",
+      "keywords": ["録画", "スクリーンショット", "スクショ", "キャプチャ"],
+      "examples": ["講義のスクショ撮っておきました", "画面録画したので共有します"]
+    },
+    {
+      "id": "course-8-ii",
+      "regulation": "講座受講規約",
+      "article": "講座受講規約 第8条(ii)",
+      "category": "講座内容無断提供",
+      "content": "講座内容の第三者への無断提供",
+      "keywords": ["講座内容", "教える", "外部", "提供", "漏らす", "答え", "ブログ"],
+      "examples": ["この課題の答え外部の人に教えてあげた", "講座の内容をブログに書きました"]
+    },
+    {
+      "id": "course-8-iv",
+      "regulation": "講座受講規約",
+      "article": "講座受講規約 第8条(iv)",
+      "category": "不正受講",
+      "content": "不正な手段による受講",
+      "keywords": ["代理", "代わり", "不正", "カンニング", "代筆", "代行"],
+      "examples": ["課題を代わりにやってもらった", "他人に受講させている"]
+    },
+    {
+      "id": "reg-3",
+      "regulation": "講座受講用アカウント登録規約",
+      "article": "講座受講用アカウント登録規約 第3条",
+      "category": "アカウント譲渡・貸与",
+      "content": "アカウント情報を第三者に利用させ、または譲渡・貸与してはなりません",
+      "keywords": ["アカウント", "ログイン", "パスワード", "貸す", "譲る", "共有"],
+      "examples": ["アカウント貸してあげるよ", "ログイン情報共有します"]
+    },
+    {
+      "id": "course-drive-url",
+      "regulation": "講座別ルール",
+      "article": "講座別ルール（DL/LLM講座）",
+      "category": "ドライブURL共有禁止",
+      "content": "GoogleドライブのURLを共有する行為（DL/LLM講座で禁止、GCIは許可）",
+      "keywords": ["ドライブ", "drive", "Drive", "Google", "URL", "リンク"],
+      "examples": ["ここにドライブのリンク貼っておきます", "Google Driveで共有しました"],
+      "applies_to": ["DL", "LLM"],
+      "excludes": ["GCI"]
+    },
+    {
+      "id": "course-guide-sharing",
+      "regulation": "講座別ルール",
+      "article": "講座別ルール（DL/LLM講座）",
+      "category": "受講手引き共有禁止",
+      "content": "受講手引きのURLやスクリーンショットを共有する行為（DL/LLM講座で禁止、GCIは許可）",
+      "keywords": ["手引き", "受講ガイド", "手順書", "ガイド"],
+      "examples": ["受講手引きのスクショ貼ります", "ガイドのURL共有しますね"],
+      "applies_to": ["DL", "LLM"],
+      "excludes": ["GCI"]
+    }
+  ]
+}

--- a/lambda/app_inspect/services/data/ng_patterns.json
+++ b/lambda/app_inspect/services/data/ng_patterns.json
@@ -1,0 +1,243 @@
+{
+  "metadata": {
+    "description": "NGワードマッチング用パターンリスト",
+    "source": "exp3_ngword_matching.pyから抽出・整理",
+    "updated": "2026-02-14"
+  },
+  "patterns": [
+    {
+      "article_id": "11-iv",
+      "category": "SNS共有禁止",
+      "pattern": "(Twitter|ツイッター|X|インスタ|Instagram|Facebook|FB|TikTok|YouTube).*(載せ|アップ|投稿|共有|シェア|晒)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-iv",
+      "category": "SNS共有禁止",
+      "pattern": "(載せ|アップ|投稿|共有|シェア|晒).*(Twitter|ツイッター|X|インスタ|Instagram|Facebook|FB|TikTok|YouTube)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-iv",
+      "category": "SNS共有禁止",
+      "pattern": "SNS.*(アップ|投稿|共有|シェア)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-iv",
+      "category": "SNS共有禁止",
+      "pattern": "スクショ.*(SNS|Twitter|X|インスタ)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-iv",
+      "category": "SNS共有禁止",
+      "pattern": "(Twitter|X)で.*(まとめ|スレッド|ツイート)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-iv",
+      "category": "SNS共有禁止",
+      "pattern": "(講義|講座|内容).*(Twitter|X)で",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-v",
+      "category": "勧誘行為",
+      "pattern": "(副業|稼げる|儲か|月収|年収).*(教え|方法|DM|連絡)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-v",
+      "category": "勧誘行為",
+      "pattern": "(投資|FX|仮想通貨|暗号資産).*(案件|儲|稼)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-v",
+      "category": "勧誘行為",
+      "pattern": "ネットワークビジネス",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-v",
+      "category": "勧誘行為",
+      "pattern": "(MLM|マルチ).*(勧誘|紹介)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-v",
+      "category": "勧誘行為",
+      "pattern": "簡単に.*(稼|儲)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-v",
+      "category": "勧誘行為",
+      "pattern": "DM.*(待|ください|下さい)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-vi",
+      "category": "録画共有禁止",
+      "pattern": "(録画|動画).*(共有|シェア|あげ|配布)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-vi",
+      "category": "録画共有禁止",
+      "pattern": "(Zoom|ズーム|講義|講座).*(録画|動画)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-vi",
+      "category": "録画共有禁止",
+      "pattern": "録画.*(持って|ありま|ください)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "edu-6",
+      "category": "コンテンツ無断配布",
+      "pattern": "(資料|教材|PDF|スライド).*(メルカリ|ヤフオク|売|転売)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "edu-6",
+      "category": "コンテンツ無断配布",
+      "pattern": "(メルカリ|ヤフオク).*(資料|教材|売)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "edu-6",
+      "category": "コンテンツ無断配布",
+      "pattern": "(資料|教材).*(友達|他人|第三者).*(シェア|共有|あげ|渡)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "edu-6",
+      "category": "コンテンツ無断配布",
+      "pattern": "(Googleドライブ|Google Drive|ドライブ).*(まとめ|共有|URL)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "edu-6",
+      "category": "コンテンツ無断配布",
+      "pattern": "(講座|講義).*(資料|教材).*(共有|シェア|配布)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-ix",
+      "category": "個人情報収集",
+      "pattern": "(連絡先|住所|電話番号|メアド|LINE).*(教えて|集め|リスト|名簿)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-ix",
+      "category": "個人情報収集",
+      "pattern": "(名簿|リスト).*(作|連絡先)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-ix",
+      "category": "個人情報収集",
+      "pattern": "皆さんの.*(情報|連絡先|本名)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-xi",
+      "category": "迷惑行為",
+      "pattern": "(うざい|きもい|キモい|死ね|消えろ|消えて|バカ|アホ|クズ)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-xi",
+      "category": "迷惑行為",
+      "pattern": "(お前|あいつ|こいつ).*(うざ|きも|むかつ)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-xii",
+      "category": "なりすまし",
+      "pattern": "(私|俺|僕)は.*(メンター|運営|スタッフ|管理者)の",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-xii",
+      "category": "なりすまし",
+      "pattern": "(メンター|運営|スタッフ)を名乗",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-xiii",
+      "category": "無許可宣伝",
+      "pattern": "(私の|僕の|俺の).*(ブログ|サイト|チャンネル|サービス).*(見て|登録|フォロー)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "11-xiii",
+      "category": "無許可宣伝",
+      "pattern": "アフィリエイト.*(リンク|URL)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "course-drive-url",
+      "category": "ドライブURL共有禁止",
+      "pattern": "(ドライブ|Drive).*(URL|リンク|共有)",
+      "courses": ["DL", "LLM"]
+    },
+    {
+      "article_id": "course-guide-sharing",
+      "category": "手引き共有禁止",
+      "pattern": "(手引き|受講ガイド).*(URL|共有|貼)",
+      "courses": ["DL", "LLM"]
+    },
+    {
+      "article_id": "edu-8-iii",
+      "category": "コンテンツ営利利用",
+      "pattern": "(教材|資料|講座).*(営利|商用|有料|セミナー)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "edu-8-iii",
+      "category": "コンテンツ営利利用",
+      "pattern": "(教材|資料|講座の内容).*(販売|売る|売り)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "course-8-ii",
+      "category": "講座内容無断提供",
+      "pattern": "(課題|講座|講義).*(答え|内容).*(外部|第三者|友達).*(教え|提供|漏)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "course-8-ii",
+      "category": "講座内容無断提供",
+      "pattern": "(講座|講義).*(内容|課題).*(ブログ|note|Qiita|Zenn).*(書|公開|投稿)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "course-8-iv",
+      "category": "不正受講",
+      "pattern": "(課題|受講|試験).*(代行|代理|代わり|代筆)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "course-8-iv",
+      "category": "不正受講",
+      "pattern": "(代わり|代理).*(受講|課題|提出)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "reg-3",
+      "category": "アカウント譲渡・貸与",
+      "pattern": "アカウント.*(貸|譲|あげ|共有|シェア)",
+      "courses": ["ALL"]
+    },
+    {
+      "article_id": "reg-3",
+      "category": "アカウント譲渡・貸与",
+      "pattern": "(ログイン|パスワード).*(教え|共有|シェア|貸)",
+      "courses": ["ALL"]
+    }
+  ]
+}

--- a/lambda/app_inspect/services/violation_detector.py
+++ b/lambda/app_inspect/services/violation_detector.py
@@ -1,0 +1,168 @@
+"""3段階違反検出モジュール: NGワード → RAG → LLM"""
+import json
+import re
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+@dataclass
+class DetectionResult:
+    is_violation: bool
+    confidence: float
+    method: str
+    article_id: Optional[str]
+    category: Optional[str]
+    reason: str
+    step_stopped: int
+
+
+def _load_json_list(path: str, key: str) -> list:
+    if not path or not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return json.load(f).get(key, [])
+
+
+class ViolationDetector:
+
+    def __init__(self, openai_client, articles_path: str = None, ng_patterns_path: str = None):
+        self.client = openai_client
+        self.articles = _load_json_list(
+            articles_path or os.path.join(_DATA_DIR, "articles.json"), "articles"
+        )
+        self.ng_patterns = _load_json_list(
+            ng_patterns_path or os.path.join(_DATA_DIR, "ng_patterns.json"), "patterns"
+        )
+        self._article_name_map = {a["id"]: a.get("article", a["id"]) for a in self.articles}
+        self._embedding_cache = {}
+
+    def detect(self, text: str, course: str = None, skip_llm: bool = False) -> DetectionResult:
+        # Step 1: NGワード
+        ng_match = self._check_ng_patterns(text, course)
+        if ng_match:
+            return DetectionResult(
+                is_violation=True,
+                confidence=1.0,
+                method="NGワード",
+                article_id=self._get_article_name(ng_match["article_id"]),
+                category=ng_match["category"],
+                reason=f"NGパターン検出: {ng_match['pattern'][:50]}",
+                step_stopped=1,
+            )
+
+        if skip_llm:
+            return DetectionResult(
+                is_violation=False, confidence=0.0, method="NGワード",
+                article_id=None, category=None,
+                reason="NGワードに該当なし", step_stopped=1,
+            )
+
+        # Step 2: RAG（関連条文を検索）
+        relevant = self._find_relevant_articles(text, course, top_k=3)
+
+        # Step 3: LLM（条文付きで判定）
+        result = self._judge_by_llm(text, relevant)
+        article_name = self._get_article_name(result.get("article_id"))
+
+        return DetectionResult(
+            is_violation=result["is_violation"],
+            confidence=result["confidence"],
+            method="LLM",
+            article_id=article_name,
+            category=result.get("category"),
+            reason=result["reason"],
+            step_stopped=3,
+        )
+
+    def _get_article_name(self, article_id: str) -> Optional[str]:
+        if not article_id:
+            return None
+        return self._article_name_map.get(article_id, article_id)
+
+    def _check_ng_patterns(self, text: str, course: str = None) -> Optional[dict]:
+        for p in self.ng_patterns:
+            courses = p.get("courses", ["ALL"])
+            if course and "ALL" not in courses and course not in courses:
+                continue
+            try:
+                if re.search(p["pattern"], text, re.IGNORECASE):
+                    return {"pattern": p["pattern"], "article_id": p["article_id"], "category": p["category"]}
+            except re.error:
+                pass
+        return None
+
+    def _find_relevant_articles(self, text: str, course: str = None, top_k: int = 3) -> list:
+        articles = self.articles
+        if course:
+            articles = [a for a in articles
+                        if "ALL" in a.get("courses", ["ALL"]) or course in a.get("courses", [])]
+
+        text_vec = self._get_embedding(text)
+        scored = []
+        for a in articles:
+            content = f"{a['content']} {' '.join(a.get('keywords', []))}"
+            aid = a["id"]
+            if aid not in self._embedding_cache:
+                self._embedding_cache[aid] = self._get_embedding(content)
+            sim = self._cosine_sim(text_vec, self._embedding_cache[aid])
+            scored.append((a, sim))
+
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return [
+            {"id": a["id"], "article": a["article"], "category": a["category"],
+             "content": a["content"], "similarity": round(sim, 3)}
+            for a, sim in scored[:top_k]
+        ]
+
+    def _judge_by_llm(self, text: str, articles: list) -> dict:
+        articles_text = "\n".join([f"- {a['article']}: {a['content']}" for a in articles])
+        prompt = f"""あなたはSlack投稿のガイドライン違反を判定するアシスタントです。
+
+## 関連する規約条文
+{articles_text}
+
+## 投稿内容
+{text}
+
+## タスク
+この投稿が上記の規約条文に違反しているか判定してください。
+
+## 出力形式（JSON）
+{{"is_violation": true/false, "confidence": 0.0-1.0, "article_id": "該当条文のID", "category": "違反カテゴリ", "reason": "判定理由"}}
+
+JSONのみを出力してください。"""
+
+        try:
+            resp = self.client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
+                temperature=0,
+            )
+            content = resp.choices[0].message.content.strip()
+            r = json.loads(content)
+            return {
+                "is_violation": r.get("is_violation", False),
+                "confidence": r.get("confidence", 0.5),
+                "article_id": r.get("article_id"),
+                "category": r.get("category"),
+                "reason": r.get("reason", ""),
+            }
+        except Exception as e:
+            return {"is_violation": False, "confidence": 0.0, "article_id": None,
+                    "category": None, "reason": f"LLM判定エラー: {e}"}
+
+    def _get_embedding(self, text: str) -> list:
+        resp = self.client.embeddings.create(model="text-embedding-3-small", input=text)
+        return resp.data[0].embedding
+
+    def _cosine_sim(self, v1: list, v2: list) -> float:
+        dot = sum(a * b for a, b in zip(v1, v2))
+        n1 = math.sqrt(sum(a * a for a in v1))
+        n2 = math.sqrt(sum(b * b for b in v2))
+        return dot / (n1 * n2) if n1 and n2 else 0.0


### PR DESCRIPTION
## Summary
- NGワード→RAG→LLMの3段階違反検出ロジックを `moderation.py` に統合
- 規約条文データ(`articles.json`: 24条文)とNGパターン(`ng_patterns.json`: 38パターン)を追加
- Slackリトライヘッダー(`X-Slack-Retry-Num`)チェックによる重複投稿防止を追加

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `handler.py` | リトライヘッダーチェック追加(+7行) |
| `services/moderation.py` | 内部ロジックをViolationDetectorに置換 |
| `services/violation_detector.py` | 3段階検出エンジン(新規) |
| `services/data/articles.json` | 規約条文データ(新規) |
| `services/data/ng_patterns.json` | NGパターンデータ(新規) |

## 検出フロー
1. **NGワード**: 正規表現で即判定(API不要、コスト0)
2. **RAG**: エンベディングで関連条文Top3を検索
3. **LLM**: 関連条文付きでOpenAIに判定依頼

## テスト
- `tests/unit/` 全8テスト通過確認済み
- `run_moderation()` のインターフェースは変更なし(既存テストとの互換性維持)