### PR TITLE
fix: create NotionDB schema and some props

### DIFF
--- a/contracts/notion_db_schema.md
+++ b/contracts/notion_db_schema.md
@@ -1,0 +1,37 @@
+# Notion Database Schema: Violation Logs
+
+Slack監視Botが違反投稿を記録・管理するためのNotionデータベース定義です。
+
+## 概要
+
+- **Database Name**: `Community Violation Logs` (任意)
+- **Description**: ガイドライン違反検知ログおよび対応ステータスの管理
+- **System**:
+    - **Write**: Lambda A (app_inspect) - 新規作成
+    - **Update**: Lambda B (app_alert) - ステータス更新
+
+## プロパティ定義
+
+| プロパティ名 | タイプ | 必須 | 説明 | 選択肢 / 設定 |
+| :--- | :--- | :--- | :--- | :--- |
+| **投稿内容** | Title | YES | 投稿内容の抜粋（検索・見出し用）。<br>※文字数制限あり（100文字推奨） | - |
+| **対応ステータス** | Select | YES | 対応状況。<br>Lambda Bによりボタン操作で更新される。 | **Options**:<br>- `Unprocessed` (初期値)<br>- `Approved` (警告送信済)<br>- `Dismissed` (対応不要) |
+| **判定結果** | Select | YES | 違反判定の結果カテゴリ。 | **Options**:<br>- `Violation`<br>- `Safe`<br>etc. |
+| **検出方法** | Select | YES | 検知に使用した手法。 | **Options**:<br>- `OpenAI`<br>- `NGWord` |
+| **確信度** | Number | NO | AI判定の確信度（0.0 - 1.0）。<br>Feat版機能の復活項目。 | 表示形式: `Percent` or `Number` |
+| **該当条文** | RichText | NO | 違反と判定された根拠となる条文ID。<br>Feat版機能の復活項目。 | - |
+| **投稿者** | RichText | YES | 投稿者のSlack User ID（または表示名）。 | - |
+| **チャンネル** | RichText | YES | 投稿されたチャンネル名/ID。 | - |
+| **投稿リンク** | URL | YES | Slackの元投稿へのPermlink。 | - |
+| **検出日時** | Date | YES | 検知日時（ISO 8601）。 | - |
+
+---
+
+## 運用上の注意（Developers Note）
+
+### ステータス値の統一
+プロパティ名（キー）は日本語ですが、**対応ステータスの選択肢（値）は英語**（`Unprocessed`, `Approved`, `Dismissed`）で統一して運用します。
+これに伴い、Lambda側のコード（`common/notion_client.py`, `app_alert/handler.py`）内のステータス文字列定数を修正する必要があります。
+
+### オプショナル項目
+`確信度` および `該当条文` は、Lambda A (app_inspect) の判定ロジック修正により値が供給されることを前提としています。

--- a/lambda/app_alert/handler.py
+++ b/lambda/app_alert/handler.py
@@ -95,16 +95,16 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
             # Notionステータス更新
             if notion_page_id:
-                log_info(ctx, action="update_notion", page_id=notion_page_id, status="対応済み")
-                notion.update_status(notion_page_id, "対応済み")
+                log_info(ctx, action="update_notion", page_id=notion_page_id, status="Approved")
+                notion.update_status(notion_page_id, "Approved")
 
             # 管理者メッセージ更新（完了表示）
             if admin_channel_id and admin_message_ts:
-                log_info(ctx, action="update_admin_message", status="対応済み")
+                log_info(ctx, action="update_admin_message", status="Approved")
                 slack.chat_update(
                     channel=admin_channel_id,
                     ts=admin_message_ts,
-                    text="対応済み",
+                    text="Approved",
                     blocks=[
                         {"type": "section", "text": {"type": "mrkdwn", "text": "✅ *対応完了* （警告送信済み）"}}
                     ]
@@ -118,16 +118,16 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 log_info(ctx, action="missing_notion_page_id", result="stop")
                 return {"statusCode": 200, "body": "Missing notion_page_id"}
 
-            log_info(ctx, action="update_notion", page_id=notion_page_id, status="dismiss")
-            notion.update_status(notion_page_id, "dismiss")
+            log_info(ctx, action="update_notion", page_id=notion_page_id, status="Dismissed")
+            notion.update_status(notion_page_id, "Dismissed")
 
             # 管理者メッセージ更新（却下表示）
             if admin_channel_id and admin_message_ts:
-                log_info(ctx, action="update_admin_message", status="dismiss")
+                log_info(ctx, action="update_admin_message", status="Dismissed")
                 slack.chat_update(
                     channel=admin_channel_id,
                     ts=admin_message_ts,
-                    text="dismiss",
+                    text="Dismissed",
                     blocks=[
                         {"type": "section", "text": {"type": "mrkdwn", "text": "🚫 *Dismissed* （対応不要）"}}
                     ]

--- a/lambda/app_inspect/handler.py
+++ b/lambda/app_inspect/handler.py
@@ -81,7 +81,9 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 severity="medium",
                 categories=["mock_test"],
                 rationale="[MOCK] 違反ワード検知",
-                recommended_reply="[MOCK] 削除を推奨します"
+                recommended_reply="[MOCK] 削除を推奨します",
+                confidence=0.9,
+                article_id="mock_article_123"
             )
         else:
             openai_client = OpenAI(api_key=cfg.openai_api_key)
@@ -109,7 +111,9 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 result="Violation",
                 method="OpenAI",
                 reason=result.rationale,
-                post_link=post_link
+                post_link=post_link,
+                article_id=result.article_id,
+                confidence=result.confidence,
             )
             log_info(ctx, action="notion_page_created", page_id=notion_page_id)
         except Exception as e:

--- a/lambda/app_inspect/services/models.py
+++ b/lambda/app_inspect/services/models.py
@@ -11,6 +11,10 @@ class ModerationResult:
     rationale: str
     recommended_reply: str
 
+    #追加のフィールドがあればここに追加
+    confidence: float = 0.0  # 例: モデルの信頼度スコア
+    article_id: str | None = None  # 例: 対象となる記事のID
+
 def normalize_result(raw: dict) -> ModerationResult:
     is_violation = bool(raw.get("is_violation", False))
     severity = str(raw.get("severity", "low")).lower()
@@ -30,6 +34,8 @@ def normalize_result(raw: dict) -> ModerationResult:
         categories=categories,
         rationale=rationale,
         recommended_reply=recommended_reply,
+        confidence=raw.get("confidence", 0.0),
+        article_id=raw.get("article_id"),
     )
 
 def severity_rank(sev: Severity) -> int:

--- a/lambda/app_inspect/services/moderation.py
+++ b/lambda/app_inspect/services/moderation.py
@@ -25,6 +25,8 @@ def run_moderation(client: OpenAI, model: str, guidelines: str, message_text: st
             "categories": [result.category] if result.category else [],
             "rationale": result.reason,
             "recommended_reply": "",
+            "confidence": result.confidence,
+            "article_id": result.article_id,
         })
     except Exception as e:
         print(f"Detection error: {e}")

--- a/lambda/common/notion_client.py
+++ b/lambda/common/notion_client.py
@@ -21,6 +21,8 @@ class NotionClient:
         method: str,
         reason: str = None,
         post_link: str = None,
+        article_id: str = None,
+        confidence: float = None,
     ) -> Optional[str]:
         """違反ログを作成し、Page IDを返す"""
         if not self.db_id:
@@ -36,12 +38,18 @@ class NotionClient:
             "検出日時": {"date": {"start": datetime.now().isoformat()}},
             "判定結果": {"select": {"name": result}},
             "検出方法": {"select": {"name": method}},
-            "対応ステータス": {"select": {"name": "未対応"}},
+            "対応ステータス": {"select": {"name": "Unprocessed"}},
         }
 
         if post_link:
             props["投稿リンク"] = {"url": post_link}
+
+        if article_id:
+            props["該当条文"] = {"rich_text": [{"text": {"content": article_id}}]}
         
+        if confidence is not None:
+            props["信頼度"] = {"number": confidence}
+
         # 理由を投稿者欄に追記（Notionのプロパティ構成に合わせて調整可）
         if reason:
             props["投稿者"]["rich_text"].append({"text": {"content": f" | 理由: {reason[:100]}"}})

--- a/tests/unit/test_a_to_b_flow_contract.py
+++ b/tests/unit/test_a_to_b_flow_contract.py
@@ -88,4 +88,4 @@ def test_A_to_B_flow_dismiss_updates_notion(
 
     # 5) Notion status を dismiss に更新する
     # ※メソッド名はあなたの実装に合わせて変更してください
-    mock_notion.update_status.assert_called_with(value_from_A["notion_page_id"], "dismiss")
+    mock_notion.update_status.assert_called_with(value_from_A["notion_page_id"], "Dismissed")

--- a/tests/unit/test_app_alert.py
+++ b/tests/unit/test_app_alert.py
@@ -62,7 +62,7 @@ def test_lambdaB_handles_fixture_interactivity_dismiss_updates_notion_and_no_rep
 
     # 2) Notion status を dismiss に更新する
     value = json.loads(payload["actions"][0]["value"])
-    mock_notion.update_status.assert_called_with(value["notion_page_id"], "dismiss")
+    mock_notion.update_status.assert_called_with(value["notion_page_id"], "Dismissed")
 
     # 3) 管理者側メッセージ更新するなら（実装している場合だけ）
     # mock_slack.chat_update.assert_called_once()

--- a/tests/unit/test_app_inspect.py
+++ b/tests/unit/test_app_inspect.py
@@ -29,6 +29,9 @@ def test_lambdaA_emits_contract_compliant_button_value(
     mock_result.is_violation = True
     mock_result.severity = "high"
     mock_result.rationale = "spam"
+
+    mock_result.confidence = 0.9
+    mock_result.article_id = "A-123"
     mocker.patch("app_inspect.handler.run_moderation", return_value=mock_result)
 
     # Slack/Notionの戻り値
@@ -50,6 +53,13 @@ def test_lambdaA_emits_contract_compliant_button_value(
     mock_slack.chat_postMessage.assert_called_once()
     _, kwargs = mock_slack.chat_postMessage.call_args
     blocks = kwargs["blocks"]
+
+    mock_notion.create_violation_log.assert_called_once()
+    call_kwargs = mock_notion.create_violation_log.call_args.kwargs
+    
+    assert call_kwargs["confidence"] == 0.9
+    assert call_kwargs["article_id"] == "A-123"
+    assert call_kwargs["post_content"] is not None
 
     # ボタン契約を検証
     btn = _find_first_button(blocks)


### PR DESCRIPTION
NotionのDBスキーマを決定。
それに合わせたnotion_clientなどの変更

| プロパティ名 | タイプ | 必須 | 説明 | 選択肢 / 設定 |
| :--- | :--- | :--- | :--- | :--- |
| **投稿内容** | Title | YES | 投稿内容の抜粋（検索・見出し用）。<br>※文字数制限あり（100文字推奨） | - |
| **対応ステータス** | Select | YES | 対応状況。<br>Lambda Bによりボタン操作で更新される。 | **Options**:<br>- `Unprocessed` (初期値)<br>- `Approved` (警告送信済)<br>- `Dismissed` (対応不要) |
| **判定結果** | Select | YES | 違反判定の結果カテゴリ。 | **Options**:<br>- `Violation`<br>- `Safe`<br>etc. |
| **検出方法** | Select | YES | 検知に使用した手法。 | **Options**:<br>- `OpenAI`<br>- `NGWord` |
| **確信度** | Number | NO | AI判定の確信度（0.0 - 1.0）。<br>Feat版機能の復活項目。 | 表示形式: `Percent` or `Number` |
| **該当条文** | RichText | NO | 違反と判定された根拠となる条文ID。<br>Feat版機能の復活項目。 | - |
| **投稿者** | RichText | YES | 投稿者のSlack User ID（または表示名）。 | - |
| **チャンネル** | RichText | YES | 投稿されたチャンネル名/ID。 | - |
| **投稿リンク** | URL | YES | Slackの元投稿へのPermlink。 | - |
| **検出日時** | Date | YES | 検知日時（ISO 8601）。 | - |