### PR TITLE
前回のPRなしCommitに追記（対応者記録など）

### DIFF
--- a/contracts/alert_button_value.schema.json
+++ b/contracts/alert_button_value.schema.json
@@ -41,6 +41,10 @@
     "notion_page_id": {
       "type": "string",
       "description": "ID of the Notion page created for this violation."
+    },
+    "article_id": {
+      "type": "string",
+      "description": "Article name/ID of the violated regulation (optional)."
     }
   },
   "additionalProperties": true

--- a/contracts/fixtures/alert_button_value.json
+++ b/contracts/fixtures/alert_button_value.json
@@ -5,5 +5,6 @@
   "origin_ts": "1700000000.12345",
   "reason": "spam",
   "policy_refs": ["p3-2"],
-  "notion_page_id": "abc123"
+  "notion_page_id": "abc123",
+  "article_id": "AI Community参加規約 第11条(iv)"
 }

--- a/contracts/fixtures/interactivity_button_click_approve.json
+++ b/contracts/fixtures/interactivity_button_click_approve.json
@@ -1,11 +1,13 @@
 {
   "team": { "id": "T_TEST" },
+  "user": { "id": "U_ADMIN_01", "name": "admin" },
   "channel": { "id": "C_PRIVATE" },
   "message": { "ts": "1700000001.00001" },
+  "container": { "channel_id": "C_PRIVATE", "message_ts": "1700000001.00001" },
   "actions": [
     {
       "action_id": "approve_violation",
-      "value": "{\"version\":\"v1\",\"trace_id\":\"slack:Ev_TEST_0001\",\"origin_channel\":\"C_ORIGIN\",\"origin_ts\":\"1700000000.12345\",\"reason\":\"spam\",\"policy_refs\":[\"p3-2\"],\"notion_page_id\":\"abc123\"}"
+      "value": "{\"version\":\"v1\",\"trace_id\":\"slack:Ev_TEST_0001\",\"origin_channel\":\"C_ORIGIN\",\"origin_ts\":\"1700000000.12345\",\"reason\":\"spam\",\"policy_refs\":[\"p3-2\"],\"notion_page_id\":\"abc123\",\"article_id\":\"AI Community参加規約 第11条(iv)\"}"
     }
   ]
 }

--- a/contracts/fixtures/interactivity_button_click_dismiss.json
+++ b/contracts/fixtures/interactivity_button_click_dismiss.json
@@ -1,11 +1,13 @@
 {
   "team": { "id": "T_TEST" },
+  "user": { "id": "U_ADMIN_01", "name": "admin" },
   "channel": { "id": "C_PRIVATE" },
   "message": { "ts": "1700000001.00001" },
+  "container": { "channel_id": "C_PRIVATE", "message_ts": "1700000001.00001" },
   "actions": [
     {
       "action_id": "dismiss_violation",
-      "value": "{\"version\":\"v1\",\"trace_id\":\"slack:Ev_TEST_0001\",\"origin_channel\":\"C_ORIGIN\",\"origin_ts\":\"1700000000.12345\",\"reason\":\"spam\",\"policy_refs\":[\"p3-2\"],\"notion_page_id\":\"abc123\"}"
+      "value": "{\"version\":\"v1\",\"trace_id\":\"slack:Ev_TEST_0001\",\"origin_channel\":\"C_ORIGIN\",\"origin_ts\":\"1700000000.12345\",\"reason\":\"spam\",\"policy_refs\":[\"p3-2\"],\"notion_page_id\":\"abc123\",\"article_id\":\"AI Community参加規約 第11条(iv)\"}"
     }
   ]
 }

--- a/contracts/notion_db_schema.md
+++ b/contracts/notion_db_schema.md
@@ -18,12 +18,15 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 | **対応ステータス** | Select | YES | 対応状況。<br>Lambda Bによりボタン操作で更新される。 | **Options**:<br>- `Unprocessed` (初期値)<br>- `Approved` (警告送信済)<br>- `Dismissed` (対応不要) |
 | **判定結果** | Select | YES | 違反判定の結果カテゴリ。 | **Options**:<br>- `Violation`<br>- `Safe`<br>etc. |
 | **検出方法** | Select | YES | 検知に使用した手法。 | **Options**:<br>- `OpenAI`<br>- `NGWord` |
-| **確信度** | Number | NO | AI判定の確信度（0.0 - 1.0）。<br>Feat版機能の復活項目。 | 表示形式: `Percent` or `Number` |
+| **信頼度** | Number | NO | AI判定の信頼度（0.0 - 1.0）。 | 表示形式: `Percent` |
 | **該当条文** | RichText | NO | 違反と判定された根拠となる条文ID。<br>Feat版機能の復活項目。 | - |
 | **投稿者** | RichText | YES | 投稿者のSlack User ID（または表示名）。 | - |
 | **チャンネル** | RichText | YES | 投稿されたチャンネル名/ID。 | - |
 | **投稿リンク** | URL | YES | Slackの元投稿へのPermlink。 | - |
 | **検出日時** | Date | YES | 検知日時（ISO 8601）。 | - |
+| **対応者** | RichText | NO | ボタンを押した管理者のSlack User ID。<br>Lambda Bにより記録される。 | - |
+| **警告送信日時** | Date | NO | 警告送信が実行された日時（ISO 8601）。<br>Lambda Bにより `Approved` 時に記録される。 | - |
+| **リマインド送信済** | Checkbox | NO | 削除依頼リマインド送信後にtrueにする。<br>Lambda C（将来実装）用。 | - |
 
 ---
 
@@ -34,4 +37,4 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 これに伴い、Lambda側のコード（`common/notion_client.py`, `app_alert/handler.py`）内のステータス文字列定数を修正する必要があります。
 
 ### オプショナル項目
-`確信度` および `該当条文` は、Lambda A (app_inspect) の判定ロジック修正により値が供給されることを前提としています。
+`信頼度` および `該当条文` は、Lambda A (app_inspect) の判定ロジック修正により値が供給されることを前提としています。

--- a/lambda/app_alert/handler.py
+++ b/lambda/app_alert/handler.py
@@ -46,7 +46,13 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
         # 2. コンテキスト解析
         action_ctx = parse_action_context(payload)
-        
+
+        # 対応者（ボタン押下者）
+        responder_id = None
+        user_info = payload.get("user")
+        if isinstance(user_info, dict):
+            responder_id = user_info.get("id")
+
         if not action_ctx or not action_ctx.action_id:
             log_info(ctx, action="ignore_action", reason="no_action_id")
             return {"statusCode": 200, "body": "OK"}
@@ -64,23 +70,24 @@ def lambda_handler(event: dict, context: Any) -> dict:
         page_id = action_ctx.value.get("notion_page_id")
 
         if action_ctx.action_id == "approve_violation":
-            # ここで action_ctx.notion_page_id を使うとエラーになります
             log_info(ctx, action="exec_approve", page_id=page_id)
             
             success = handle_approve_violation(
-                ctx=action_ctx, 
-                slack=slack, 
-                notion=notion, 
-                reply_text=cfg.reply_prefix
+                ctx=action_ctx,
+                slack=slack,
+                notion=notion,
+                reply_text=cfg.reply_prefix,
+                responder_id=responder_id,
             )
 
         elif action_ctx.action_id == "dismiss_violation":
             log_info(ctx, action="exec_dismiss", page_id=page_id)
-            
+
             success = handle_dismiss_violation(
-                ctx=action_ctx, 
-                slack=slack, 
-                notion=notion
+                ctx=action_ctx,
+                slack=slack,
+                notion=notion,
+                responder_id=responder_id,
             )
 
         if success:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ def mock_external_services(mocker):
     mock_slack_client = mocker.MagicMock()
     mock_openai_client = mocker.MagicMock()
     mock_notion_client = mocker.MagicMock()
+    mock_notion_client.check_duplicate_violation.return_value = False
 
     mocker.patch("app_inspect.handler.SignatureVerifier", return_value=mock_verifier)
     mocker.patch("app_alert.handler.SignatureVerifier", return_value=mock_verifier)

--- a/tests/unit/test_a_to_b_flow_contract.py
+++ b/tests/unit/test_a_to_b_flow_contract.py
@@ -41,6 +41,8 @@ def test_A_to_B_flow_dismiss_updates_notion(
     mock_result.is_violation = True
     mock_result.severity = "high"
     mock_result.rationale = "spam"
+    mock_result.confidence = 0.9
+    mock_result.article_id = "A-123"
     mocker.patch("app_inspect.handler.run_moderation", return_value=mock_result)
 
     mock_slack.chat_getPermalink.return_value = {"permalink": "http://slack.com/p1"}
@@ -87,5 +89,7 @@ def test_A_to_B_flow_dismiss_updates_notion(
     mock_slack.chat_postMessage.assert_not_called()
 
     # 5) Notion status を dismiss に更新する
-    # ※メソッド名はあなたの実装に合わせて変更してください
-    mock_notion.update_status.assert_called_with(value_from_A["notion_page_id"], "Dismissed")
+    mock_notion.update_status.assert_called_once()
+    call_args = mock_notion.update_status.call_args
+    assert call_args.args[0] == value_from_A["notion_page_id"]
+    assert call_args.args[1] == "Dismissed"

--- a/tests/unit/test_app_alert.py
+++ b/tests/unit/test_app_alert.py
@@ -62,7 +62,10 @@ def test_lambdaB_handles_fixture_interactivity_dismiss_updates_notion_and_no_rep
 
     # 2) Notion status を dismiss に更新する
     value = json.loads(payload["actions"][0]["value"])
-    mock_notion.update_status.assert_called_with(value["notion_page_id"], "Dismissed")
+    mock_notion.update_status.assert_called_once()
+    call_args = mock_notion.update_status.call_args
+    assert call_args.args[0] == value["notion_page_id"]
+    assert call_args.args[1] == "Dismissed"
 
     # 3) 管理者側メッセージ更新するなら（実装している場合だけ）
     # mock_slack.chat_update.assert_called_once()

--- a/tests/unit/test_app_inspect.py
+++ b/tests/unit/test_app_inspect.py
@@ -60,6 +60,7 @@ def test_lambdaA_emits_contract_compliant_button_value(
     assert call_kwargs["confidence"] == 0.9
     assert call_kwargs["article_id"] == "A-123"
     assert call_kwargs["post_content"] is not None
+    assert call_kwargs.get("message_ts") is not None
 
     # ボタン契約を検証
     btn = _find_first_button(blocks)
@@ -75,3 +76,4 @@ def test_lambdaA_emits_contract_compliant_button_value(
     assert value["origin_channel"] == ev["channel"]
     assert value["origin_ts"] == ev["ts"]
     assert value["trace_id"] == f"slack:{body['event_id']}"
+    assert value.get("article_id") == "A-123"


### PR DESCRIPTION
- notion_client: 重複チェック(check_duplicate_violation)追加、
  update_statusにwarning_sent_at/responder_id対応、バグ修正
- app_inspect: 二重処理防止、ボタン値にarticle_id追加
- app_alert: ボタン押下者(responder_id)をNotion記録
- actions: 条文名入り警告文生成(build_warning_text)、旧handle_approve削除
- contracts: スキーマにarticle_id追加、信頼度名称統一、DB定義更新