### PR TITLE
feat: Lambda C(app_remind)追加 + Lambda A/Bテンプレート対応（コンフリクト対応版）

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@
 repo/
 ├── infra/                 # AWS CDK (API Gateway / Lambda / IAM / etc.)
 ├── lambda/                # Lambdaのアプリコード（関数単位）
-│   ├── app_inspect/       # Slack投稿を受け取り検査（OpenAI等）→ Slack返信
-│   └── app_alert/         # 承認ボタン等を受け取り → 元投稿へ勧告通知
+│   ├── app_inspect/       # Lambda A: Slack投稿を受け取り検査（OpenAI等）→ アラート通知
+│   ├── app_alert/         # Lambda B: 承認ボタン等を受け取り → 元投稿へ警告通知
+│   ├── app_remind/        # Lambda C: Approved後48h経過した投稿にリマインド送信
+│   └── common/            # 共通モジュール（Notion, SSM, Observability）
+├── contracts/             # Lambda間データ契約（スキーマ, フィクスチャ）
+├── tests/                 # ユニットテスト
 ├── evals/                 # プロンプト評価（例: promptfoo など）
 └── prompts/               # 本番用プロンプト置き場（必要に応じて）
 
@@ -20,33 +24,46 @@ repo/
 
 
 ### infra/
-AWSインフラ定義（CDK）を置くディレクトリです。  
+AWSインフラ定義（CDK）を置くディレクトリです。
 API Gateway / Lambda / IAM 等の構成は原則ここでコード管理します。
 
 - 役割：インフラの再現性確保・変更履歴の可視化
 - 注意：AWSコンソールでの手動変更は原則禁止（緊急時のみ、後でCDKへ反映）
 
-### app/
+### lambda/
 Lambdaで動作するアプリケーションコード（Botの本体）を置くディレクトリです。
 
-#### app/handlers/
-Lambdaの「入口（エンドポイント単位）」です。  
-Slackからのリクエストを受け、署名検証・リクエスト解析・ACK返却など“薄い処理”を行い、必要に応じて `services/` を呼び出します。
+各Lambda関数は `handler.py`（エントリポイント）と `services/`（業務ロジック）で構成されます。
 
-- 例：/health、/slack/events、/slack/interactions など
-- ポイント：重い処理（OpenAI推論、Notion書き込み、Slack投稿など）はなるべく `services/` 側へ寄せる
+#### 3-Lambda アーキテクチャ
 
-#### app/services/
-業務ロジック（Botの中核処理）を置くディレクトリです。  
-違反判定（OpenAI推論）、Notionの参照/ログ保存、Slackへの投稿/スレッド返信などの処理をここにまとめます。
+```
+Slack投稿 → [Lambda A: app_inspect] → 違反検出 → Notion記録 + 管理者アラート
+                                                         ↓ ボタン操作
+                                          [Lambda B: app_alert] → 警告送信 or Dismiss
+                                                         ↓ Approved後48h経過
+                                          [Lambda C: app_remind] → 削除リマインド送信
+```
 
-- 役割：機能の中心・テストしやすい構造にするための分離
+| Lambda | トリガー | 役割 |
+|--------|---------|------|
+| **A (app_inspect)** | Slack Event API | 投稿を受信 → 3段階違反検出 → Notionログ + 管理者通知 |
+| **B (app_alert)** | Slack Interactivity | 管理者ボタン操作 → 警告送信 or Dismiss → Notion更新 |
+| **C (app_remind)** | EventBridge (定期) | Notionポーリング → 48h経過分にリマインド送信 |
+
+#### common/
+共通モジュール（全Lambda関数で共有）:
+- `notion_client.py` - Notion API操作（作成・更新・クエリ・リマインド管理）
+- `secret_manager.py` - SSM Parameter Store からシークレット取得
+- `observability.py` - 構造化ログ・CloudWatch EMFメトリクス・トレーシング
 
 ### evals/
-プロンプトの評価・改善（promptfoo等）を行うためのディレクトリです。  
-本番コード（app/）に影響を与えずに、ローカルやCIで高速にプロンプト比較・回帰テストを行います。
+プロンプトの評価・改善（promptfoo等）を行うためのディレクトリです。
 
-#### evals/prompts/
-評価対象のプロンプト案を置きます（v1/v2などを並べて比較する想定、promptfooの管理想定）。
+### contracts/
+Lambda間のデータ契約を定義:
+- `alert_button_value.schema.json` - Lambda A→B ボタン値のJSONスキーマ
+- `notion_db_schema.md` - Notion DBプロパティ定義
+- `fixtures/` - テスト用フィクスチャデータ
 
 

--- a/contracts/notion_db_schema.md
+++ b/contracts/notion_db_schema.md
@@ -9,6 +9,7 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 - **System**:
     - **Write**: Lambda A (app_inspect) - 新規作成
     - **Update**: Lambda B (app_alert) - ステータス更新
+    - **Read/Update**: Lambda C (app_remind) - リマインド対象クエリ + フラグ更新
 
 ## プロパティ定義
 
@@ -26,7 +27,8 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 | **検出日時** | Date | YES | 検知日時（ISO 8601）。 | - |
 | **対応者** | RichText | NO | ボタンを押した管理者のSlack User ID。<br>Lambda Bにより記録される。 | - |
 | **警告送信日時** | Date | NO | 警告送信が実行された日時（ISO 8601）。<br>Lambda Bにより `Approved` 時に記録される。 | - |
-| **リマインド送信済** | Checkbox | NO | 削除依頼リマインド送信後にtrueにする。<br>Lambda C（将来実装）用。 | - |
+| **ワークスペース** | Select | NO | Slackワークスペース名。<br>Lambda A が投稿リンクから自動抽出して設定。<br>マルチワークスペース管理・フィルタ用。 | 動的（ワークスペース名） |
+| **リマインド送信済** | Checkbox | NO | 削除依頼リマインド送信後にtrueにする。<br>Lambda C (app_remind) が更新。 | - |
 
 ---
 
@@ -38,3 +40,14 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 
 ### オプショナル項目
 `信頼度` および `該当条文` は、Lambda A (app_inspect) の判定ロジック修正により値が供給されることを前提としています。
+
+### Lambda C (app_remind) のクエリ条件
+```
+対応ステータス = "Approved" AND リマインド送信済 = false
+```
+該当レコードに対し、`警告送信日時` から48時間経過していればリマインドを送信。
+`警告送信日時` が空の場合は `last_edited_time`（ページ最終更新日時）をフォールバックとして使用。
+
+### ワークスペースプロパティ
+Lambda A が `投稿リンク` のパーマリンク（`https://{workspace}.slack.com/archives/...`）からワークスペース名を抽出し、`ワークスペース` selectプロパティに自動設定。
+Notion上でワークスペース別にフィルタ・ビューを作成することで、マルチワークスペース環境での横断管理が可能。

--- a/lambda/app_alert/handler.py
+++ b/lambda/app_alert/handler.py
@@ -1,6 +1,5 @@
 import json
 import base64
-import os
 from typing import Any
 from urllib.parse import parse_qs
 from slack_sdk import WebClient
@@ -9,7 +8,7 @@ from slack_sdk.signature import SignatureVerifier
 from common.observability import build_context, log_info, log_error, emit_metric, Timer
 from common.notion_client import NotionClient
 from .services.config import load_config
-from .services.actions import parse_action_context, handle_approve_violation, handle_dismiss_violation
+from .services.actions import parse_action_context, extract_template_page_id, handle_approve_violation, handle_dismiss_violation
 
 SERVICE = "app_alert"
 
@@ -71,13 +70,18 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
         if action_ctx.action_id == "approve_violation":
             log_info(ctx, action="exec_approve", page_id=page_id)
-            
+
+            template_page_id = extract_template_page_id(payload)
+
             success = handle_approve_violation(
                 ctx=action_ctx,
                 slack=slack,
                 notion=notion,
                 reply_text=cfg.reply_prefix,
                 responder_id=responder_id,
+                template_page_id=template_page_id,
+                notion_api_key=cfg.notion_api_key,
+                template_db_id=cfg.notion_template_db_id,
             )
 
         elif action_ctx.action_id == "dismiss_violation":

--- a/lambda/app_alert/services/actions.py
+++ b/lambda/app_alert/services/actions.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     from slack_sdk import WebClient
     from common.notion_client import NotionClient
 
+from common.template_manager import resolve_template, render_template
+
 logger = logging.getLogger(__name__)
 
 _ARTICLES_DIR = os.path.join(
@@ -47,6 +49,15 @@ def parse_action_context(payload: dict) -> ActionContext | None:
         admin_channel=container.get("channel_id"),
         admin_message_ts=container.get("message_ts"),
     )
+
+
+def extract_template_page_id(payload: dict) -> str:
+    """Slackペイロードのstate.valuesからテンプレート選択値を取得"""
+    state_values = payload.get("state", {}).get("values", {})
+    select_block = state_values.get("template_select_block", {})
+    select_action = select_block.get("template_select", {})
+    selected = select_action.get("selected_option")
+    return selected["value"] if selected else ""
 
 
 def _load_articles() -> dict[str, dict]:
@@ -91,6 +102,9 @@ def handle_approve_violation(
     notion: "NotionClient",
     reply_text: str,
     responder_id: str | None = None,
+    template_page_id: str = "",
+    notion_api_key: str = "",
+    template_db_id: str = "",
 ) -> bool:
     origin_channel = ctx.value.get("origin_channel")
     origin_ts = ctx.value.get("origin_ts")
@@ -101,7 +115,25 @@ def handle_approve_violation(
         logger.error("Missing origin info for approve action")
         return False
 
-    warning_text = build_warning_text(reply_text, article_id)
+    # テンプレートDB連携: template_page_idがあればテンプレート解決を使用
+    if template_page_id and notion_api_key:
+        template_body = resolve_template(
+            "警告",
+            api_key=notion_api_key,
+            db_id=template_db_id,
+            template_page_id=template_page_id,
+        )
+        # 条文名を解決（article_idからNotionの条文マスタを参照）
+        article_name = article_id or ""
+        if article_id:
+            article_page_id = notion.find_article_page_id(article_id)
+            if article_page_id:
+                resolved_name = notion.get_article_name(article_page_id)
+                if resolved_name:
+                    article_name = resolved_name
+        warning_text = render_template(template_body, article=article_name)
+    else:
+        warning_text = build_warning_text(reply_text, article_id)
 
     try:
         slack.chat_postMessage(
@@ -117,6 +149,8 @@ def handle_approve_violation(
             if responder_id:
                 update_kwargs["responder_id"] = responder_id
             notion.update_status(notion_page_id, "Approved", **update_kwargs)
+            if template_page_id:
+                notion.set_template_relation(notion_page_id, template_page_id)
             logger.info(f"Updated Notion {notion_page_id} to Approved")
 
         if ctx.admin_channel and ctx.admin_message_ts:

--- a/lambda/app_alert/services/config.py
+++ b/lambda/app_alert/services/config.py
@@ -11,6 +11,7 @@ class AlertConfig:
 
     # Env Vars
     notion_db_id: str
+    notion_template_db_id: str
     reply_prefix: str
 
 def load_config() -> AlertConfig:
@@ -23,6 +24,7 @@ def load_config() -> AlertConfig:
         notion_api_key=get_secret("NOTION_API_KEY_PARAM_NAME"),
         
         notion_db_id=_get_env("NOTION_DB_ID"),
+        notion_template_db_id=_get_env("NOTION_TEMPLATE_DB_ID"),
         reply_prefix=_get_env(
             "REPLY_PREFIX",
             default="この投稿はコミュニティガイドラインに抵触する可能性があります。内容をご確認の上、削除または修正をお願いします。",

--- a/lambda/app_inspect/handler.py
+++ b/lambda/app_inspect/handler.py
@@ -97,7 +97,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
         # 7. 外部連携
         try:
-            notion = NotionClient(cfg.notion_api_key, cfg.notion_db_id)
+            notion = NotionClient(cfg.notion_api_key, cfg.notion_db_id, cfg.notion_articles_db_id)
             slack_client = WebClient(token=cfg.slack_bot_token)
 
             # 重複チェック（同じ投稿の二重処理防止）

--- a/lambda/app_inspect/handler.py
+++ b/lambda/app_inspect/handler.py
@@ -8,11 +8,44 @@ from openai import OpenAI
 # commonモジュールのインポート
 from common.observability import build_context, log_info, log_error, emit_metric, Timer
 from common.notion_client import NotionClient
+from common.template_manager import get_template_options
 from .services.config import load_config
 from .services.moderation import run_moderation, encode_alert_button_value
 from .services.models import severity_rank, ModerationResult
 
 SERVICE = "app_inspect"
+
+
+def _build_template_select_block(
+    api_key: str, db_id: str,
+) -> dict | None:
+    """テンプレートDBからstatic_selectブロックを構築。取得失敗時はNone。"""
+    templates = get_template_options(api_key, db_id)
+    if not templates:
+        return None
+
+    options = [
+        {"text": {"type": "plain_text", "text": t["name"][:75]}, "value": t["page_id"]}
+        for t in templates
+    ]
+    select_element: dict = {
+        "type": "static_select",
+        "action_id": "template_select",
+        "placeholder": {"type": "plain_text", "text": "テンプレート選択"},
+        "options": options,
+    }
+    default = next((t for t in templates if t["usage"] == "警告"), None)
+    if default:
+        select_element["initial_option"] = {
+            "text": {"type": "plain_text", "text": default["name"][:75]},
+            "value": default["page_id"],
+        }
+    return {
+        "type": "actions",
+        "block_id": "template_select_block",
+        "elements": [select_element],
+    }
+
 
 def lambda_handler(event: dict, context: Any) -> dict:
     # 1. コンテキスト初期化（この時点でSlackのIDなどが自動抽出される）
@@ -151,25 +184,35 @@ def lambda_handler(event: dict, context: Any) -> dict:
                     ),
                 },
             },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": {"type": "plain_text", "text": "削除勧告を送る"},
-                        "style": "danger",
-                        "action_id": "approve_violation",
-                        "value": button_value,
-                    },
-                    {
-                        "type": "button",
-                        "text": {"type": "plain_text", "text": "Dismiss（対応不要）"},
-                        "action_id": "dismiss_violation",
-                        "value": button_value,
-                    },
-                ],
-            },
         ]
+
+        # テンプレート選択プルダウン（テンプレートDBが設定されている場合のみ）
+        if cfg.notion_template_db_id:
+            try:
+                select_block = _build_template_select_block(cfg.notion_api_key, cfg.notion_template_db_id)
+                if select_block:
+                    blocks.append(select_block)
+            except Exception as e:
+                log_error(ctx, action="fetch_templates", error=e)
+
+        blocks.append({
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "削除勧告を送る"},
+                    "style": "danger",
+                    "action_id": "approve_violation",
+                    "value": button_value,
+                },
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Dismiss（対応不要）"},
+                    "action_id": "dismiss_violation",
+                    "value": button_value,
+                },
+            ],
+        })
 
         slack_client.chat_postMessage(channel=cfg.alert_private_channel_id, text="【違反検知アラート】", blocks=blocks)
 

--- a/lambda/app_inspect/services/config.py
+++ b/lambda/app_inspect/services/config.py
@@ -13,6 +13,7 @@ class InspectConfig:
 
     notion_api_key: str
     notion_db_id: str
+    notion_articles_db_id: str
 
     guidelines_text: str
     min_severity_to_alert: str
@@ -45,6 +46,7 @@ def load_config() -> InspectConfig:
         
         alert_private_channel_id=_get_env("ALERT_PRIVATE_CHANNEL_ID", required=True),
         notion_db_id=_get_env("NOTION_DB_ID"),
+        notion_articles_db_id=_get_env("NOTION_ARTICLES_DB_ID"),
         
         openai_model=_get_env("OPENAI_MODEL", default="gpt-4o-mini"),
         guidelines_text=_get_env("GUIDELINES_TEXT", default=""),

--- a/lambda/app_inspect/services/config.py
+++ b/lambda/app_inspect/services/config.py
@@ -14,6 +14,7 @@ class InspectConfig:
     notion_api_key: str
     notion_db_id: str
     notion_articles_db_id: str
+    notion_template_db_id: str
 
     guidelines_text: str
     min_severity_to_alert: str
@@ -47,6 +48,7 @@ def load_config() -> InspectConfig:
         alert_private_channel_id=_get_env("ALERT_PRIVATE_CHANNEL_ID", required=True),
         notion_db_id=_get_env("NOTION_DB_ID"),
         notion_articles_db_id=_get_env("NOTION_ARTICLES_DB_ID"),
+        notion_template_db_id=_get_env("NOTION_TEMPLATE_DB_ID"),
         
         openai_model=_get_env("OPENAI_MODEL", default="gpt-4o-mini"),
         guidelines_text=_get_env("GUIDELINES_TEXT", default=""),

--- a/lambda/app_remind/handler.py
+++ b/lambda/app_remind/handler.py
@@ -1,0 +1,61 @@
+"""Lambda C (app_remind): EventBridgeトリガーで削除リマインドを送信する"""
+
+import os
+from typing import Any
+
+from slack_sdk import WebClient
+
+from common.observability import build_context, log_info, log_error, emit_metric, Timer
+from common.notion_client import NotionClient
+from common.secret_manager import get_secret
+from .services.config import load_config
+from .services.reminder import process_reminders
+
+SERVICE = "app_remind"
+
+
+def _build_workspace_clients() -> dict[str, WebClient]:
+    """SLACK_BOT_TOKEN__{workspace}_PARAM_NAME 形式のSSMパラメータから
+    ワークスペース別クライアントを構築する"""
+    workspace_clients: dict[str, WebClient] = {}
+
+    for key in os.environ:
+        if key.startswith("SLACK_BOT_TOKEN__") and key.endswith("_PARAM_NAME"):
+            workspace = key.removeprefix("SLACK_BOT_TOKEN__").removesuffix("_PARAM_NAME").lower()
+            token = get_secret(key)
+            if token:
+                workspace_clients[workspace] = WebClient(token=token)
+
+    return workspace_clients
+
+
+def lambda_handler(event: dict, context: Any) -> dict:
+    ctx = build_context(event, context, service=SERVICE)
+    total_timer = Timer()
+    log_info(ctx, action="request_received")
+
+    try:
+        cfg = load_config()
+
+        slack = WebClient(token=cfg.slack_bot_token)
+        workspace_clients = _build_workspace_clients()
+
+        notion = NotionClient(cfg.notion_api_key, cfg.notion_db_id)
+
+        stats = process_reminders(
+            slack=slack,
+            notion=notion,
+            hours_threshold=cfg.hours_threshold,
+            slack_clients=workspace_clients,
+        )
+
+        elapsed_ms = total_timer.ms()
+        log_info(ctx, action="completed", stats=stats, elapsed_ms=round(elapsed_ms, 1))
+        emit_metric(ctx, "TotalLatencyMs", elapsed_ms, unit="Milliseconds")
+
+        return {"statusCode": 200, "body": "ok"}
+
+    except Exception as e:
+        log_error(ctx, action="handler_failed", error=e)
+        emit_metric(ctx, "RemindError", 1)
+        return {"statusCode": 200, "body": "error_handled"}

--- a/lambda/app_remind/handler.py
+++ b/lambda/app_remind/handler.py
@@ -47,6 +47,8 @@ def lambda_handler(event: dict, context: Any) -> dict:
             notion=notion,
             hours_threshold=cfg.hours_threshold,
             slack_clients=workspace_clients,
+            notion_api_key=cfg.notion_api_key,
+            template_db_id=cfg.template_db_id,
         )
 
         elapsed_ms = total_timer.ms()

--- a/lambda/app_remind/services/config.py
+++ b/lambda/app_remind/services/config.py
@@ -1,0 +1,27 @@
+import os
+from dataclasses import dataclass
+from common.secret_manager import get_secret
+
+
+@dataclass(frozen=True)
+class RemindConfig:
+    # Secrets
+    slack_bot_token: str
+    notion_api_key: str
+
+    # Env Vars
+    notion_db_id: str
+    hours_threshold: int
+
+
+def load_config() -> RemindConfig:
+    def _get_env(name: str, default: str = "") -> str:
+        return os.getenv(name, default)
+
+    return RemindConfig(
+        slack_bot_token=get_secret("SLACK_BOT_TOKEN_PARAM_NAME"),
+        notion_api_key=get_secret("NOTION_API_KEY_PARAM_NAME"),
+
+        notion_db_id=_get_env("NOTION_DB_ID"),
+        hours_threshold=int(_get_env("REMINDER_HOURS_THRESHOLD", "48")),
+    )

--- a/lambda/app_remind/services/config.py
+++ b/lambda/app_remind/services/config.py
@@ -11,6 +11,7 @@ class RemindConfig:
 
     # Env Vars
     notion_db_id: str
+    template_db_id: str
     hours_threshold: int
 
 
@@ -23,5 +24,6 @@ def load_config() -> RemindConfig:
         notion_api_key=get_secret("NOTION_API_KEY_PARAM_NAME"),
 
         notion_db_id=_get_env("NOTION_DB_ID"),
+        template_db_id=_get_env("NOTION_TEMPLATE_DB_ID"),
         hours_threshold=int(_get_env("REMINDER_HOURS_THRESHOLD", "48")),
     )

--- a/lambda/app_remind/services/reminder.py
+++ b/lambda/app_remind/services/reminder.py
@@ -1,0 +1,179 @@
+"""削除リマインドサービス: Notionポーリングで初回警告送信 + 48h後リマインド送信"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+from common.notion_client import NotionClient
+
+logger = logging.getLogger(__name__)
+
+WARNING_MESSAGE = (
+    ":warning: *ガイドライン違反の通知*\n\n"
+    "この投稿はコミュニティガイドラインに抵触する可能性があるため、"
+    "投稿の削除または修正をお願いします。\n"
+    "ご不明点がありましたら管理者までお問い合わせください。"
+)
+
+REMINDER_MESSAGE = (
+    ":bell: *削除リマインド*\n\n"
+    "この投稿はコミュニティガイドラインに抵触する可能性があるため、"
+    "削除のお願いをしておりました。\n\n"
+    "まだ投稿が残っているようですので、ご確認・削除をお願いいたします。\n"
+    "ご不明点がありましたら管理者までお問い合わせください。"
+)
+
+TITLE_TRUNCATE_LEN = 50
+
+
+def check_message_exists(slack: WebClient, channel_id: str, message_ts: str) -> bool:
+    """元投稿がまだ存在するか確認"""
+    try:
+        resp = slack.conversations_history(
+            channel=channel_id,
+            oldest=message_ts,
+            latest=message_ts,
+            inclusive=True,
+            limit=1,
+        )
+        messages = resp.get("messages", [])
+        return len(messages) > 0 and messages[0].get("ts") == message_ts
+    except SlackApiError as e:
+        logger.error("Message existence check failed (%s/%s): %s", channel_id, message_ts, e)
+        return False
+
+
+def send_warning(slack: WebClient, channel_id: str, message_ts: str) -> bool:
+    """スレッド返信で初回警告を送信"""
+    try:
+        slack.chat_postMessage(
+            channel=channel_id,
+            thread_ts=message_ts,
+            text=WARNING_MESSAGE,
+        )
+        return True
+    except SlackApiError as e:
+        logger.error("Failed to send warning (%s/%s): %s", channel_id, message_ts, e)
+        return False
+
+
+def send_reminder(slack: WebClient, channel_id: str, message_ts: str) -> bool:
+    """スレッド返信でリマインドを送信"""
+    try:
+        slack.chat_postMessage(
+            channel=channel_id,
+            thread_ts=message_ts,
+            text=REMINDER_MESSAGE,
+        )
+        return True
+    except SlackApiError as e:
+        logger.error("Failed to send reminder (%s/%s): %s", channel_id, message_ts, e)
+        return False
+
+
+def _resolve_slack_client(
+    workspace: Optional[str],
+    slack_clients: dict[str, WebClient],
+    default_client: WebClient,
+) -> WebClient:
+    """ワークスペース名からSlackクライアントを解決する"""
+    if workspace and workspace in slack_clients:
+        return slack_clients[workspace]
+    return default_client
+
+
+def process_reminders(
+    slack: WebClient,
+    notion: NotionClient,
+    hours_threshold: int = 48,
+    dry_run: bool = False,
+    slack_clients: Optional[dict[str, WebClient]] = None,
+) -> dict[str, int]:
+    """Notionポーリングによる警告・リマインド処理のメインロジック
+
+    Approved かつ リマインド未送信のレコードを取得し、以下を処理:
+    - 警告送信日時が空 → 初回警告を送信 + 警告送信日時を記録
+    - 警告送信日時あり + hours_threshold経過 → リマインドを送信
+
+    Args:
+        slack: デフォルトのSlack WebClient
+        notion: NotionClient インスタンス
+        hours_threshold: 警告後何時間でリマインドするか
+        dry_run: Trueの場合、実際の送信・更新をしない
+        slack_clients: ワークスペース名 -> WebClient のマッピング（マルチワークスペース対応）
+    """
+    if slack_clients is None:
+        slack_clients = {}
+
+    stats: dict[str, int] = {
+        "queried": 0,
+        "warned": 0,
+        "skipped_not_elapsed": 0,
+        "skipped_no_link": 0,
+        "already_deleted": 0,
+        "reminded": 0,
+        "errors": 0,
+    }
+
+    pages = notion.query_approved_unreminded()
+    stats["queried"] = len(pages)
+    logger.info("Found %d approved & unreminded records", len(pages))
+
+    for page in pages:
+        fields = notion.extract_reminder_fields(page)
+        page_id: str = fields["page_id"]
+        title: str = fields["title"][:TITLE_TRUNCATE_LEN]
+
+        parsed = notion.parse_slack_link(fields["post_link"])
+        if not parsed:
+            logger.warning("[SKIP] No valid post_link: %s", title)
+            stats["skipped_no_link"] += 1
+            continue
+
+        channel_id, message_ts, workspace = parsed
+        client = _resolve_slack_client(workspace, slack_clients, slack)
+
+        if not check_message_exists(client, channel_id, message_ts):
+            logger.info("[DELETED] Message already deleted: %s", title)
+            stats["already_deleted"] += 1
+            if not dry_run:
+                notion.mark_reminded(page_id)
+            continue
+
+        # 警告送信日時が空 → 初回警告送信（Notion手動Approve等）
+        if fields["warning_sent_at"] is None:
+            if dry_run:
+                logger.info("[DRY RUN] Would send warning: %s -> %s/%s (ws=%s)", title, channel_id, message_ts, workspace)
+            else:
+                if send_warning(client, channel_id, message_ts):
+                    logger.info("[WARNED] Warning sent: %s (ws=%s)", title, workspace)
+                    notion.update_status(page_id, "Approved", warning_sent_at=datetime.now(timezone.utc))
+                else:
+                    stats["errors"] += 1
+                    continue
+            stats["warned"] += 1
+            continue
+
+        # 警告送信日時あり → 閾値経過チェック → リマインド送信
+        if not notion.is_past_threshold(fields["warning_sent_at"], hours_threshold):
+            logger.info("[SKIP] Not yet %dh: %s", hours_threshold, title)
+            stats["skipped_not_elapsed"] += 1
+            continue
+
+        if dry_run:
+            logger.info("[DRY RUN] Would send reminder: %s -> %s/%s (ws=%s)", title, channel_id, message_ts, workspace)
+            stats["reminded"] += 1
+        else:
+            if send_reminder(client, channel_id, message_ts):
+                logger.info("[SENT] Reminder sent: %s (ws=%s)", title, workspace)
+                stats["reminded"] += 1
+                if not notion.mark_reminded(page_id):
+                    logger.error("Failed to mark reminded: %s", page_id)
+                    stats["errors"] += 1
+            else:
+                stats["errors"] += 1
+
+    return stats

--- a/lambda/app_remind/services/reminder.py
+++ b/lambda/app_remind/services/reminder.py
@@ -1,4 +1,4 @@
-"""削除リマインドサービス: Notionポーリングで初回警告送信 + 48h後リマインド送信"""
+"""削除リマインドサービス: Notionポーリングで初回警告送信 + 48h後Notion更新"""
 
 import logging
 from datetime import datetime, timezone
@@ -50,10 +50,6 @@ def send_warning(slack: WebClient, channel_id: str, message_ts: str, text: str) 
     return _send_thread_message(slack, channel_id, message_ts, text, "warning")
 
 
-def send_reminder(slack: WebClient, channel_id: str, message_ts: str, text: str) -> bool:
-    return _send_thread_message(slack, channel_id, message_ts, text, "reminder")
-
-
 def _resolve_slack_client(
     workspace: Optional[str],
     slack_clients: dict[str, WebClient],
@@ -100,8 +96,8 @@ def process_reminders(
     """Notionポーリングによる警告・リマインド処理のメインロジック
 
     Approved かつ リマインド未送信のレコードを取得し、以下を処理:
-    - 警告送信日時が空 → 初回警告を送信 + 警告送信日時を記録
-    - 警告送信日時あり + hours_threshold経過 → リマインドを送信
+    - 警告送信日時が空 → 違反投稿スレッドに初回警告を送信 + 警告送信日時を記録
+    - 警告送信日時あり + hours_threshold経過 → Notion上でリマインド済みに更新（Slack送信なし）
 
     Args:
         slack: デフォルトのSlack WebClient
@@ -156,8 +152,17 @@ def process_reminders(
                 notion.mark_reminded(page_id)
             continue
 
-        # 警告送信日時が空 → 初回警告送信（Notion手動Approve等）
+        # 警告送信日時が空 → 初回警告を違反投稿スレッドに送信
         if fields["warning_sent_at"] is None:
+            # Lambda Bとの競合防止: 送信前にNotionを再取得して確認
+            fresh_page = notion.get_page(page_id)
+            if fresh_page:
+                fresh_fields = notion.extract_reminder_fields(fresh_page)
+                if fresh_fields["warning_sent_at"] is not None:
+                    logger.info("[SKIP] Already warned by Lambda B: %s", title)
+                    stats["skipped_not_elapsed"] += 1
+                    continue
+
             message = _build_message("警告", fields, notion_api_key, template_db_id)
             if dry_run:
                 logger.info("[DRY RUN] Would send warning: %s -> %s/%s (ws=%s)", title, channel_id, message_ts, workspace)
@@ -171,24 +176,21 @@ def process_reminders(
             stats["warned"] += 1
             continue
 
-        # 警告送信日時あり → 閾値経過チェック → リマインド送信
+        # 警告送信日時あり → 閾値経過チェック → Notion上でリマインド済みに更新（Slack送信なし）
         if not notion.is_past_threshold(fields["warning_sent_at"], hours_threshold):
             logger.info("[SKIP] Not yet %dh: %s", hours_threshold, title)
             stats["skipped_not_elapsed"] += 1
             continue
 
-        message = _build_message("リマインド", fields, notion_api_key, template_db_id)
         if dry_run:
-            logger.info("[DRY RUN] Would send reminder: %s -> %s/%s (ws=%s)", title, channel_id, message_ts, workspace)
+            logger.info("[DRY RUN] Would mark reminded: %s", title)
             stats["reminded"] += 1
         else:
-            if send_reminder(client, channel_id, message_ts, message):
-                logger.info("[SENT] Reminder sent: %s (ws=%s)", title, workspace)
+            if notion.mark_reminded(page_id):
+                logger.info("[REMINDED] Marked as reminded (Notion only): %s", title)
                 stats["reminded"] += 1
-                if not notion.mark_reminded(page_id):
-                    logger.error("Failed to mark reminded: %s", page_id)
-                    stats["errors"] += 1
             else:
+                logger.error("Failed to mark reminded: %s", page_id)
                 stats["errors"] += 1
 
     return stats

--- a/lambda/app_remind/services/reminder.py
+++ b/lambda/app_remind/services/reminder.py
@@ -8,23 +8,9 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from common.notion_client import NotionClient
+from common.template_manager import resolve_template, render_template, compose_message
 
 logger = logging.getLogger(__name__)
-
-WARNING_MESSAGE = (
-    ":warning: *ガイドライン違反の通知*\n\n"
-    "この投稿はコミュニティガイドラインに抵触する可能性があるため、"
-    "投稿の削除または修正をお願いします。\n"
-    "ご不明点がありましたら管理者までお問い合わせください。"
-)
-
-REMINDER_MESSAGE = (
-    ":bell: *削除リマインド*\n\n"
-    "この投稿はコミュニティガイドラインに抵触する可能性があるため、"
-    "削除のお願いをしておりました。\n\n"
-    "まだ投稿が残っているようですので、ご確認・削除をお願いいたします。\n"
-    "ご不明点がありましたら管理者までお問い合わせください。"
-)
 
 TITLE_TRUNCATE_LEN = 50
 
@@ -46,32 +32,26 @@ def check_message_exists(slack: WebClient, channel_id: str, message_ts: str) -> 
         return False
 
 
-def send_warning(slack: WebClient, channel_id: str, message_ts: str) -> bool:
-    """スレッド返信で初回警告を送信"""
+def _send_thread_message(slack: WebClient, channel_id: str, message_ts: str, text: str, log_prefix: str) -> bool:
+    """スレッド返信でメッセージを送信"""
     try:
         slack.chat_postMessage(
             channel=channel_id,
             thread_ts=message_ts,
-            text=WARNING_MESSAGE,
+            text=text,
         )
         return True
     except SlackApiError as e:
-        logger.error("Failed to send warning (%s/%s): %s", channel_id, message_ts, e)
+        logger.error("Failed to send %s (%s/%s): %s", log_prefix, channel_id, message_ts, e)
         return False
 
 
-def send_reminder(slack: WebClient, channel_id: str, message_ts: str) -> bool:
-    """スレッド返信でリマインドを送信"""
-    try:
-        slack.chat_postMessage(
-            channel=channel_id,
-            thread_ts=message_ts,
-            text=REMINDER_MESSAGE,
-        )
-        return True
-    except SlackApiError as e:
-        logger.error("Failed to send reminder (%s/%s): %s", channel_id, message_ts, e)
-        return False
+def send_warning(slack: WebClient, channel_id: str, message_ts: str, text: str) -> bool:
+    return _send_thread_message(slack, channel_id, message_ts, text, "warning")
+
+
+def send_reminder(slack: WebClient, channel_id: str, message_ts: str, text: str) -> bool:
+    return _send_thread_message(slack, channel_id, message_ts, text, "reminder")
 
 
 def _resolve_slack_client(
@@ -85,12 +65,37 @@ def _resolve_slack_client(
     return default_client
 
 
+def _build_message(usage: str, fields: dict, notion_api_key: str = "", template_db_id: str = "") -> str:
+    """用途に応じたメッセージを組み立てる
+
+    優先順位:
+    1. Relation指定（template_page_id）→ そのテンプレート
+    2. テンプレートDB → 用途に一致するもの
+    3. フォールバック
+    """
+    template_body = resolve_template(
+        usage,
+        api_key=notion_api_key,
+        db_id=template_db_id,
+        template_page_id=fields.get("template_page_id", ""),
+    )
+    rendered = render_template(
+        template_body,
+        article=fields.get("article_id") or "",
+        post_link=fields.get("post_link") or "",
+        poster=fields.get("poster") or "",
+    )
+    return compose_message(rendered, fields.get("additional_message", ""))
+
+
 def process_reminders(
     slack: WebClient,
     notion: NotionClient,
     hours_threshold: int = 48,
     dry_run: bool = False,
     slack_clients: Optional[dict[str, WebClient]] = None,
+    notion_api_key: str = "",
+    template_db_id: str = "",
 ) -> dict[str, int]:
     """Notionポーリングによる警告・リマインド処理のメインロジック
 
@@ -104,6 +109,8 @@ def process_reminders(
         hours_threshold: 警告後何時間でリマインドするか
         dry_run: Trueの場合、実際の送信・更新をしない
         slack_clients: ワークスペース名 -> WebClient のマッピング（マルチワークスペース対応）
+        notion_api_key: テンプレートDB取得用（空ならフォールバック使用）
+        template_db_id: テンプレートDBのID（空ならフォールバック使用）
     """
     if slack_clients is None:
         slack_clients = {}
@@ -127,6 +134,12 @@ def process_reminders(
         page_id: str = fields["page_id"]
         title: str = fields["title"][:TITLE_TRUNCATE_LEN]
 
+        # 対象条文 Relation から条文名を解決（article_id より優先）
+        if fields.get("article_page_id"):
+            article_name = notion.get_article_name(fields["article_page_id"])
+            if article_name:
+                fields["article_id"] = article_name
+
         parsed = notion.parse_slack_link(fields["post_link"])
         if not parsed:
             logger.warning("[SKIP] No valid post_link: %s", title)
@@ -145,10 +158,11 @@ def process_reminders(
 
         # 警告送信日時が空 → 初回警告送信（Notion手動Approve等）
         if fields["warning_sent_at"] is None:
+            message = _build_message("警告", fields, notion_api_key, template_db_id)
             if dry_run:
                 logger.info("[DRY RUN] Would send warning: %s -> %s/%s (ws=%s)", title, channel_id, message_ts, workspace)
             else:
-                if send_warning(client, channel_id, message_ts):
+                if send_warning(client, channel_id, message_ts, message):
                     logger.info("[WARNED] Warning sent: %s (ws=%s)", title, workspace)
                     notion.update_status(page_id, "Approved", warning_sent_at=datetime.now(timezone.utc))
                 else:
@@ -163,11 +177,12 @@ def process_reminders(
             stats["skipped_not_elapsed"] += 1
             continue
 
+        message = _build_message("リマインド", fields, notion_api_key, template_db_id)
         if dry_run:
             logger.info("[DRY RUN] Would send reminder: %s -> %s/%s (ws=%s)", title, channel_id, message_ts, workspace)
             stats["reminded"] += 1
         else:
-            if send_reminder(client, channel_id, message_ts):
+            if send_reminder(client, channel_id, message_ts, message):
                 logger.info("[SENT] Reminder sent: %s (ws=%s)", title, workspace)
                 stats["reminded"] += 1
                 if not notion.mark_reminded(page_id):

--- a/lambda/common/notion_client.py
+++ b/lambda/common/notion_client.py
@@ -1,9 +1,15 @@
 import logging
-import requests
-from datetime import datetime
+import re
+from datetime import datetime, timezone
 from typing import Optional, Any
 
+import requests
+
 logger = logging.getLogger(__name__)
+
+_NOTION_API_BASE = "https://api.notion.com/v1"
+_SLACK_LINK_PATTERN = re.compile(r"/archives/([A-Z0-9]+)/p(\d+)")
+_SLACK_WORKSPACE_PATTERN = re.compile(r"https://([^.]+)\.slack\.com/archives/")
 
 
 class NotionClient:
@@ -18,7 +24,7 @@ class NotionClient:
 
     def _query(self, filter_obj: dict = None) -> list:
         """Notion DBクエリ（ページネーション対応）"""
-        url = f"https://api.notion.com/v1/databases/{self.db_id}/query"
+        url = f"{_NOTION_API_BASE}/databases/{self.db_id}/query"
         results = []
         cursor = None
 
@@ -91,6 +97,9 @@ class NotionClient:
 
         if post_link:
             props["投稿リンク"] = {"url": post_link}
+            ws = self.parse_slack_link(post_link)
+            if ws and ws[2]:
+                props["ワークスペース"] = {"select": {"name": ws[2]}}
 
         if article_id:
             props["該当条文"] = {"rich_text": [{"text": {"content": article_id}}]}
@@ -98,7 +107,7 @@ class NotionClient:
         if confidence is not None:
             props["信頼度"] = {"number": confidence}
 
-        url = "https://api.notion.com/v1/pages"
+        url = f"{_NOTION_API_BASE}/pages"
         payload = {
             "parent": {"database_id": self.db_id},
             "properties": props
@@ -116,6 +125,21 @@ class NotionClient:
             logger.error(f"Create failed: {e}")
             return None
 
+    def _update_page(self, page_id: str, props: dict[str, Any]) -> bool:
+        """ページプロパティを更新する共通メソッド"""
+        url = f"{_NOTION_API_BASE}/pages/{page_id}"
+        try:
+            resp = requests.patch(
+                url, headers=self.headers, json={"properties": props}, timeout=5
+            )
+            if not resp.ok:
+                logger.error(f"Page update failed for {page_id}: {resp.status_code} {resp.text}")
+                return False
+            return True
+        except Exception as e:
+            logger.error(f"Page update failed for {page_id}: {e}")
+            return False
+
     def update_status(
         self,
         page_id: str,
@@ -124,8 +148,6 @@ class NotionClient:
         responder_id: str = None,
     ) -> bool:
         """ページのステータスを更新する。対応者・警告送信日時も任意で記録。"""
-        url = f"https://api.notion.com/v1/pages/{page_id}"
-
         props: dict[str, Any] = {
             "対応ステータス": {"select": {"name": status}}
         }
@@ -134,12 +156,96 @@ class NotionClient:
         if responder_id:
             props["対応者"] = {"rich_text": [{"text": {"content": responder_id}}]}
 
+        return self._update_page(page_id, props)
+
+    # ---- Lambda C (app_remind) 用メソッド ----
+
+    def query_approved_unreminded(self) -> list[dict[str, Any]]:
+        """Approved かつ リマインド未送信のレコードを取得"""
+        return self._query({
+            "and": [
+                {"property": "対応ステータス", "select": {"equals": "Approved"}},
+                {"property": "リマインド送信済", "checkbox": {"equals": False}},
+            ]
+        })
+
+    def mark_reminded(self, page_id: str) -> bool:
+        """リマインド送信済フラグを True に更新"""
+        return self._update_page(page_id, {"リマインド送信済": {"checkbox": True}})
+
+    @staticmethod
+    def parse_slack_link(url: Optional[str]) -> Optional[tuple[str, str, Optional[str]]]:
+        """Slackパーマリンクから (channel_id, message_ts, workspace) を抽出
+
+        例: https://myworkspace.slack.com/archives/C09EFRG58SW/p1234567890123456
+          -> ("C09EFRG58SW", "1234567890.123456", "myworkspace")
+        """
+        if not url:
+            return None
+
+        match = _SLACK_LINK_PATTERN.search(url)
+        if not match:
+            return None
+
+        channel_id = match.group(1)
+        raw_ts = match.group(2)
+        message_ts = f"{raw_ts[:10]}.{raw_ts[10:]}" if len(raw_ts) > 10 else raw_ts
+
+        ws_match = _SLACK_WORKSPACE_PATTERN.search(url)
+        workspace = ws_match.group(1) if ws_match else None
+
+        return channel_id, message_ts, workspace
+
+    @staticmethod
+    def extract_reminder_fields(page: dict[str, Any]) -> dict[str, Any]:
+        """Notionページからリマインド処理に必要なフィールドを抽出
+
+        warning_sent_at は明示的な「警告送信日時」のみ返す（フォールバックなし）。
+        - None → 初回警告が未送信（Notion手動Approve等）
+        - 値あり → Lambda B またはLambda C が既に警告送信済み
+        """
+        props = page.get("properties", {})
+
+        post_link = props.get("投稿リンク", {}).get("url")
+
+        warning_date_obj = props.get("警告送信日時", {}).get("date")
+        warning_sent_at = None
+        if warning_date_obj and warning_date_obj.get("start"):
+            warning_sent_at = warning_date_obj["start"]
+
+        poster_texts = props.get("投稿者", {}).get("rich_text", [])
+        poster = poster_texts[0]["plain_text"] if poster_texts else None
+
+        title_texts = props.get("投稿内容", {}).get("title", [])
+        title = title_texts[0]["plain_text"] if title_texts else ""
+
+        article_texts = props.get("該当条文", {}).get("rich_text", [])
+        article_id = article_texts[0]["plain_text"] if article_texts else None
+
+        return {
+            "page_id": page["id"],
+            "post_link": post_link,
+            "warning_sent_at": warning_sent_at,
+            "poster": poster,
+            "title": title,
+            "article_id": article_id,
+        }
+
+    @staticmethod
+    def is_past_threshold(warning_sent_at: Optional[str], hours: int) -> bool:
+        """警告送信日時からhours時間経過しているか判定"""
+        if not warning_sent_at:
+            return False
+
         try:
-            resp = requests.patch(
-                url, headers=self.headers, json={"properties": props}, timeout=5
-            )
-            resp.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Update failed: {e}")
+            ts = warning_sent_at.replace("Z", "+00:00") if warning_sent_at.endswith("Z") else warning_sent_at
+            sent_dt = datetime.fromisoformat(ts)
+
+            if sent_dt.tzinfo is None:
+                sent_dt = sent_dt.replace(tzinfo=timezone.utc)
+
+            elapsed_hours = (datetime.now(timezone.utc) - sent_dt).total_seconds() / 3600
+            return elapsed_hours >= hours
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Failed to parse warning_sent_at '{warning_sent_at}': {e}")
             return False

--- a/lambda/common/notion_client.py
+++ b/lambda/common/notion_client.py
@@ -219,6 +219,12 @@ class NotionClient:
             ]
         })
 
+    def set_template_relation(self, page_id: str, template_page_id: str) -> bool:
+        """使用テンプレートRelationを設定"""
+        return self._update_page(page_id, {
+            "使用テンプレート": {"relation": [{"id": template_page_id}]},
+        })
+
     def mark_reminded(self, page_id: str) -> bool:
         """リマインド送信済フラグを True に更新"""
         return self._update_page(page_id, {"リマインド送信済": {"checkbox": True}})

--- a/lambda/common/notion_client.py
+++ b/lambda/common/notion_client.py
@@ -175,6 +175,19 @@ class NotionClient:
             logger.error("Article page fetch failed for %s: %s", page_id, e)
             return None
 
+    def get_page(self, page_id: str) -> Optional[dict]:
+        """ページ情報を取得する"""
+        url = f"{_NOTION_API_BASE}/pages/{page_id}"
+        try:
+            resp = requests.get(url, headers=self.headers, timeout=10)
+            if not resp.ok:
+                logger.error("Page fetch failed for %s: %s", page_id, resp.status_code)
+                return None
+            return resp.json()
+        except Exception as e:
+            logger.error("Page fetch failed for %s: %s", page_id, e)
+            return None
+
     def _update_page(self, page_id: str, props: dict[str, Any]) -> bool:
         """ページプロパティを更新する共通メソッド"""
         url = f"{_NOTION_API_BASE}/pages/{page_id}"

--- a/lambda/common/notion_client.py
+++ b/lambda/common/notion_client.py
@@ -13,9 +13,10 @@ _SLACK_WORKSPACE_PATTERN = re.compile(r"https://([^.]+)\.slack\.com/archives/")
 
 
 class NotionClient:
-    def __init__(self, api_key: str, db_id: str):
+    def __init__(self, api_key: str, db_id: str, articles_db_id: str = ""):
         self.api_key = api_key
         self.db_id = db_id
+        self.articles_db_id = articles_db_id
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Notion-Version": "2022-06-28",
@@ -103,6 +104,10 @@ class NotionClient:
 
         if article_id:
             props["該当条文"] = {"rich_text": [{"text": {"content": article_id}}]}
+            # 条文DBへのRelation設定（page_idが見つかった場合）
+            article_page_id = self.find_article_page_id(article_id)
+            if article_page_id:
+                props["対象条文"] = {"relation": [{"id": article_page_id}]}
 
         if confidence is not None:
             props["信頼度"] = {"number": confidence}
@@ -123,6 +128,51 @@ class NotionClient:
             return resp.json().get("id")
         except Exception as e:
             logger.error(f"Create failed: {e}")
+            return None
+
+    def find_article_page_id(self, article_id: str) -> Optional[str]:
+        """条文ID（例: "11-iv"）から条文DBのpage_idを検索する"""
+        if not self.articles_db_id or not article_id:
+            return None
+
+        url = f"{_NOTION_API_BASE}/databases/{self.articles_db_id}/query"
+        body = {
+            "filter": {
+                "property": "条文ID",
+                "title": {"equals": article_id},
+            },
+            "page_size": 1,
+        }
+
+        try:
+            resp = requests.post(url, headers=self.headers, json=body, timeout=10)
+            if not resp.ok:
+                logger.error("Article lookup failed for %s: %s", article_id, resp.status_code)
+                return None
+            results = resp.json().get("results", [])
+            return results[0]["id"] if results else None
+        except Exception as e:
+            logger.error("Article lookup failed for %s: %s", article_id, e)
+            return None
+
+    def get_article_name(self, page_id: str) -> Optional[str]:
+        """条文ページのpage_idから条文名（条項番号）を取得する"""
+        url = f"{_NOTION_API_BASE}/pages/{page_id}"
+        try:
+            resp = requests.get(url, headers=self.headers, timeout=10)
+            if not resp.ok:
+                logger.error("Article page fetch failed for %s: %s", page_id, resp.status_code)
+                return None
+            props = resp.json().get("properties", {})
+            # 条項番号（rich_text）から条文名を取得
+            article_texts = props.get("条項番号", {}).get("rich_text", [])
+            if article_texts:
+                return article_texts[0].get("plain_text")
+            # フォールバック: タイトル（条文ID）を返す
+            title_texts = props.get("条文ID", {}).get("title", [])
+            return title_texts[0].get("plain_text") if title_texts else None
+        except Exception as e:
+            logger.error("Article page fetch failed for %s: %s", page_id, e)
             return None
 
     def _update_page(self, page_id: str, props: dict[str, Any]) -> bool:
@@ -222,6 +272,17 @@ class NotionClient:
         article_texts = props.get("該当条文", {}).get("rich_text", [])
         article_id = article_texts[0]["plain_text"] if article_texts else None
 
+        additional_texts = props.get("追加メッセージ", {}).get("rich_text", [])
+        additional_message = additional_texts[0]["plain_text"] if additional_texts else ""
+
+        # Relation: 使用テンプレート（最初の1件のpage_idを取得）
+        relation_items = props.get("使用テンプレート", {}).get("relation", [])
+        template_page_id = relation_items[0]["id"] if relation_items else ""
+
+        # Relation: 対象条文（条文DBへのリンク）
+        article_relation = props.get("対象条文", {}).get("relation", [])
+        article_page_id = article_relation[0]["id"] if article_relation else ""
+
         return {
             "page_id": page["id"],
             "post_link": post_link,
@@ -229,6 +290,9 @@ class NotionClient:
             "poster": poster,
             "title": title,
             "article_id": article_id,
+            "article_page_id": article_page_id,
+            "additional_message": additional_message,
+            "template_page_id": template_page_id,
         }
 
     @staticmethod

--- a/lambda/common/template_manager.py
+++ b/lambda/common/template_manager.py
@@ -1,0 +1,173 @@
+"""警告テンプレート管理: Notion DBからテンプレートを取得し、キャッシュ+プレースホルダー置換"""
+
+import logging
+import time
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_NOTION_API_BASE = "https://api.notion.com/v1"
+_CACHE_TTL_SECONDS = 30 * 60  # 30分
+
+# モジュールレベルキャッシュ（Warm Start間で保持）
+_template_cache: dict[str, dict[str, str]] = {}
+_cache_loaded_at: float = 0.0
+
+FALLBACK_TEMPLATES: dict[str, str] = {
+    "警告": (
+        ":warning: *ガイドライン違反の通知*\n\n"
+        "この投稿はコミュニティガイドラインに抵触する可能性があるため、"
+        "投稿の削除または修正をお願いします。\n"
+        "ご不明点がありましたら管理者までお問い合わせください。"
+    ),
+    "リマインド": (
+        ":bell: *削除リマインド*\n\n"
+        "この投稿はコミュニティガイドラインに抵触する可能性があるため、"
+        "削除のお願いをしておりました。\n\n"
+        "まだ投稿が残っているようですので、ご確認・削除をお願いいたします。\n"
+        "ご不明点がありましたら管理者までお問い合わせください。"
+    ),
+}
+
+
+def _fetch_templates(api_key: str, db_id: str) -> list[dict[str, Any]]:
+    """テンプレートDBから有効なレコードを取得"""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": "2022-06-28",
+        "Content-Type": "application/json",
+    }
+    url = f"{_NOTION_API_BASE}/databases/{db_id}/query"
+    body = {
+        "filter": {"property": "有効", "checkbox": {"equals": True}},
+    }
+    resp = requests.post(url, headers=headers, json=body, timeout=10)
+    if not resp.ok:
+        raise Exception(f"Template DB query failed: {resp.status_code} {resp.text}")
+    return resp.json().get("results", [])
+
+
+def _parse_template(page: dict[str, Any]) -> Optional[dict[str, str]]:
+    """Notionページからテンプレート情報を抽出"""
+    props = page.get("properties", {})
+
+    name_parts = props.get("テンプレート名", {}).get("title", [])
+    name = name_parts[0]["plain_text"].strip() if name_parts else None
+
+    usage_obj = props.get("用途", {}).get("select")
+    usage = usage_obj["name"] if usage_obj else None
+
+    body_parts = props.get("本文", {}).get("rich_text", [])
+    body = "".join(part["plain_text"] for part in body_parts) if body_parts else ""
+
+    if not name or not usage or not body:
+        return None
+
+    return {"name": name, "usage": usage, "body": body}
+
+
+def get_templates(api_key: str, db_id: str, force_refresh: bool = False) -> dict[str, dict[str, str]]:
+    """テンプレートを取得（キャッシュ付き）
+
+    Returns:
+        {"警告": {"name": "標準警告", "body": "..."}, "リマインド": {"name": "...", "body": "..."}}
+    """
+    global _template_cache, _cache_loaded_at
+
+    now = time.time()
+    cache_valid = _template_cache and (now - _cache_loaded_at < _CACHE_TTL_SECONDS)
+
+    if cache_valid and not force_refresh:
+        return _template_cache
+
+    if not db_id:
+        return {}
+
+    try:
+        pages = _fetch_templates(api_key, db_id)
+        templates: dict[str, dict[str, str]] = {}
+        for page in pages:
+            parsed = _parse_template(page)
+            if parsed:
+                templates[parsed["usage"]] = {"name": parsed["name"], "body": parsed["body"]}
+
+        _template_cache = templates
+        _cache_loaded_at = now
+        logger.info("Template cache refreshed: %d templates", len(templates))
+        return _template_cache
+
+    except Exception as e:
+        logger.error("Failed to fetch templates: %s", e)
+        if _template_cache:
+            logger.warning("Using stale template cache")
+            return _template_cache
+        return {}
+
+
+def get_template_by_page_id(api_key: str, page_id: str) -> Optional[str]:
+    """Relation指定されたテンプレートのpage_idから本文を取得"""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": "2022-06-28",
+    }
+    url = f"{_NOTION_API_BASE}/pages/{page_id}"
+    try:
+        resp = requests.get(url, headers=headers, timeout=10)
+        if not resp.ok:
+            logger.error("Failed to fetch template page %s: %s", page_id, resp.status_code)
+            return None
+        page = resp.json()
+        parsed = _parse_template(page)
+        if parsed and parsed["body"]:
+            return parsed["body"]
+        return None
+    except Exception as e:
+        logger.error("Failed to fetch template page %s: %s", page_id, e)
+        return None
+
+
+def resolve_template(
+    usage: str,
+    api_key: str = "",
+    db_id: str = "",
+    template_page_id: str = "",
+) -> str:
+    """用途に応じたテンプレート本文を返す（フォールバック付き）
+
+    優先順位:
+    1. template_page_id（Relation指定） → そのテンプレートの本文
+    2. db_id（テンプレートDB） → 用途に一致するテンプレート
+    3. FALLBACK_TEMPLATES（ハードコード）
+    """
+    # 1. Relation指定のテンプレート
+    if template_page_id and api_key:
+        body = get_template_by_page_id(api_key, template_page_id)
+        if body:
+            return body
+        logger.warning("Relation template not found, falling back: %s", template_page_id)
+
+    # 2. テンプレートDBから用途で検索
+    if api_key and db_id:
+        templates = get_templates(api_key, db_id)
+        if usage in templates:
+            return templates[usage]["body"]
+
+    # 3. ハードコードフォールバック
+    return FALLBACK_TEMPLATES.get(usage, FALLBACK_TEMPLATES["警告"])
+
+
+def render_template(body: str, **kwargs: str) -> str:
+    """プレースホルダーを置換。未定義は残す。"""
+    for key, value in kwargs.items():
+        body = body.replace(f"{{{{{key}}}}}", str(value))
+    return body
+
+
+def compose_message(template_body: str, additional_message: str = "") -> str:
+    """テンプレート + 追加メッセージを結合"""
+    message = template_body
+    if additional_message and additional_message.strip():
+        message += "\n\n" + additional_message.strip()
+    return message

--- a/lambda/common/template_manager.py
+++ b/lambda/common/template_manager.py
@@ -106,6 +106,31 @@ def get_templates(api_key: str, db_id: str, force_refresh: bool = False) -> dict
         return {}
 
 
+def get_template_options(api_key: str, db_id: str) -> list[dict[str, str]]:
+    """Slack static_select用: 有効な全テンプレートを page_id 付きで返す
+
+    Returns:
+        [{"page_id": "...", "name": "標準警告", "usage": "警告"}, ...]
+    """
+    if not db_id:
+        return []
+    try:
+        pages = _fetch_templates(api_key, db_id)
+        options = []
+        for page in pages:
+            parsed = _parse_template(page)
+            if parsed:
+                options.append({
+                    "page_id": page["id"],
+                    "name": parsed["name"],
+                    "usage": parsed["usage"],
+                })
+        return options
+    except Exception as e:
+        logger.error("Failed to fetch template options: %s", e)
+        return []
+
+
 def get_template_by_page_id(api_key: str, page_id: str) -> Optional[str]:
     """Relation指定されたテンプレートのpage_idから本文を取得"""
     headers = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ def mock_config(mocker):
 
     mocker.patch("app_inspect.handler.load_config", return_value=mock_conf)
     mocker.patch("app_alert.handler.load_config", return_value=mock_conf)
+    mocker.patch("app_remind.handler.load_config", return_value=mock_conf)
     return mock_conf
 
 

--- a/tests/unit/test_app_remind.py
+++ b/tests/unit/test_app_remind.py
@@ -1,0 +1,787 @@
+"""Lambda C (app_remind) ユニットテスト"""
+
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from common.notion_client import NotionClient
+from app_remind.services.reminder import (
+    check_message_exists,
+    send_warning,
+    send_reminder,
+    process_reminders,
+    _resolve_slack_client,
+)
+from common.template_manager import (
+    FALLBACK_TEMPLATES,
+    resolve_template,
+    get_template_by_page_id,
+)
+
+
+# ---- NotionClient static methods ----
+
+class TestParseSlackLink:
+    def test_standard_url(self):
+        url = "https://myworkspace.slack.com/archives/C09EFRG58SW/p1234567890123456"
+        result = NotionClient.parse_slack_link(url)
+        assert result == ("C09EFRG58SW", "1234567890.123456", "myworkspace")
+
+    def test_no_workspace_url(self):
+        url = "https://slack.com/archives/C09EFRG58SW/p1234567890123456"
+        result = NotionClient.parse_slack_link(url)
+        assert result == ("C09EFRG58SW", "1234567890.123456", None)
+
+    def test_short_ts(self):
+        url = "https://test.slack.com/archives/C12345/p1234567890"
+        result = NotionClient.parse_slack_link(url)
+        assert result == ("C12345", "1234567890", "test")
+
+    def test_none_url(self):
+        assert NotionClient.parse_slack_link(None) is None
+
+    def test_empty_url(self):
+        assert NotionClient.parse_slack_link("") is None
+
+    def test_invalid_url(self):
+        assert NotionClient.parse_slack_link("https://example.com") is None
+
+
+class TestExtractReminderFields:
+    def test_full_fields(self):
+        page = {
+            "id": "page-123",
+            "properties": {
+                "投稿リンク": {"url": "https://ws.slack.com/archives/C123/p111"},
+                "警告送信日時": {"date": {"start": "2026-01-01T00:00:00Z"}},
+                "投稿者": {"rich_text": [{"plain_text": "U_USER"}]},
+                "投稿内容": {"title": [{"plain_text": "テスト投稿"}]},
+                "該当条文": {"rich_text": [{"plain_text": "第3条"}]},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["page_id"] == "page-123"
+        assert fields["post_link"] == "https://ws.slack.com/archives/C123/p111"
+        assert fields["warning_sent_at"] == "2026-01-01T00:00:00Z"
+        assert fields["poster"] == "U_USER"
+        assert fields["title"] == "テスト投稿"
+        assert fields["article_id"] == "第3条"
+
+    def test_no_warning_sent_at_returns_none(self):
+        """警告送信日時が空の場合、フォールバックなしでNoneを返す"""
+        page = {
+            "id": "page-456",
+            "last_edited_time": "2026-01-15T12:00:00.000Z",
+            "properties": {
+                "投稿リンク": {"url": None},
+                "警告送信日時": {"date": None},
+                "投稿者": {"rich_text": []},
+                "投稿内容": {"title": []},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["warning_sent_at"] is None
+        assert fields["poster"] is None
+        assert fields["title"] == ""
+
+    def test_explicit_warning_preferred(self):
+        page = {
+            "id": "p",
+            "last_edited_time": "2026-02-01T00:00:00Z",
+            "properties": {
+                "警告送信日時": {"date": {"start": "2026-01-01T00:00:00Z"}},
+                "投稿リンク": {},
+                "投稿者": {"rich_text": []},
+                "投稿内容": {"title": []},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["warning_sent_at"] == "2026-01-01T00:00:00Z"
+
+    def test_missing_properties(self):
+        page = {"id": "p", "properties": {}}
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["page_id"] == "p"
+        assert fields["post_link"] is None
+        assert fields["warning_sent_at"] is None
+        assert fields["article_id"] is None
+        assert fields["template_page_id"] == ""
+
+    def test_relation_template(self):
+        """使用テンプレートRelationからpage_idを抽出"""
+        page = {
+            "id": "p",
+            "properties": {
+                "使用テンプレート": {"relation": [{"id": "tmpl-page-123"}]},
+                "投稿リンク": {"url": None},
+                "警告送信日時": {"date": None},
+                "投稿者": {"rich_text": []},
+                "投稿内容": {"title": []},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["template_page_id"] == "tmpl-page-123"
+
+    def test_relation_empty(self):
+        """使用テンプレートRelationが未設定の場合は空文字"""
+        page = {
+            "id": "p",
+            "properties": {
+                "使用テンプレート": {"relation": []},
+                "投稿リンク": {"url": None},
+                "警告送信日時": {"date": None},
+                "投稿者": {"rich_text": []},
+                "投稿内容": {"title": []},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["template_page_id"] == ""
+
+    def test_article_relation(self):
+        """対象条文Relationからpage_idを抽出"""
+        page = {
+            "id": "p",
+            "properties": {
+                "対象条文": {"relation": [{"id": "article-page-1"}]},
+                "投稿リンク": {"url": None},
+                "警告送信日時": {"date": None},
+                "投稿者": {"rich_text": []},
+                "投稿内容": {"title": []},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["article_page_id"] == "article-page-1"
+
+    def test_article_relation_empty(self):
+        """対象条文Relationが未設定の場合は空文字"""
+        page = {
+            "id": "p",
+            "properties": {
+                "対象条文": {"relation": []},
+                "投稿リンク": {"url": None},
+                "警告送信日時": {"date": None},
+                "投稿者": {"rich_text": []},
+                "投稿内容": {"title": []},
+            },
+        }
+        fields = NotionClient.extract_reminder_fields(page)
+        assert fields["article_page_id"] == ""
+
+
+class TestIsPastThreshold:
+    def test_past_threshold(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=50)).isoformat()
+        assert NotionClient.is_past_threshold(past, 48) is True
+
+    def test_not_past_threshold(self):
+        recent = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+        assert NotionClient.is_past_threshold(recent, 48) is False
+
+    def test_none_returns_false(self):
+        assert NotionClient.is_past_threshold(None, 48) is False
+
+    def test_invalid_string(self):
+        assert NotionClient.is_past_threshold("not-a-date", 48) is False
+
+    def test_z_suffix(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=50)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert NotionClient.is_past_threshold(past, 48) is True
+
+    def test_zero_hours(self):
+        recent = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        assert NotionClient.is_past_threshold(recent, 0) is True
+
+
+# ---- Workspace property in create_violation_log ----
+
+class TestWorkspaceProperty:
+    def test_workspace_set_from_post_link(self):
+        """create_violation_log がワークスペースプロパティを設定すること"""
+        notion = NotionClient(api_key="test", db_id="db")
+        with patch("common.notion_client.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.ok = True
+            mock_resp.json.return_value = {"id": "page-1"}
+            mock_post.return_value = mock_resp
+
+            notion.create_violation_log(
+                post_content="test",
+                user_id="U1",
+                channel="C1",
+                result="Violation",
+                method="OpenAI",
+                post_link="https://myws.slack.com/archives/C123/p111",
+            )
+
+            call_args = mock_post.call_args
+            props = call_args.kwargs["json"]["properties"]
+            assert props["ワークスペース"] == {"select": {"name": "myws"}}
+
+    def test_article_relation_set_from_article_id(self):
+        """article_idが指定されたとき、対象条文Relationが設定されること"""
+        notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
+        with patch("common.notion_client.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.ok = True
+            mock_resp.json.return_value = {"id": "page-1"}
+            mock_post.return_value = mock_resp
+
+            with patch.object(notion, "find_article_page_id", return_value="article-page-123"):
+                notion.create_violation_log(
+                    post_content="test",
+                    user_id="U1",
+                    channel="C1",
+                    result="Violation",
+                    method="OpenAI",
+                    article_id="11-iv",
+                )
+
+            call_args = mock_post.call_args
+            props = call_args.kwargs["json"]["properties"]
+            assert props["該当条文"] == {"rich_text": [{"text": {"content": "11-iv"}}]}
+            assert props["対象条文"] == {"relation": [{"id": "article-page-123"}]}
+
+    def test_article_relation_not_set_when_not_found(self):
+        """articles_dbにarticle_idが見つからない場合はRelation設定されないこと"""
+        notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
+        with patch("common.notion_client.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.ok = True
+            mock_resp.json.return_value = {"id": "page-1"}
+            mock_post.return_value = mock_resp
+
+            with patch.object(notion, "find_article_page_id", return_value=None):
+                notion.create_violation_log(
+                    post_content="test",
+                    user_id="U1",
+                    channel="C1",
+                    result="Violation",
+                    method="OpenAI",
+                    article_id="unknown-id",
+                )
+
+            call_args = mock_post.call_args
+            props = call_args.kwargs["json"]["properties"]
+            assert props["該当条文"] == {"rich_text": [{"text": {"content": "unknown-id"}}]}
+            assert "対象条文" not in props
+
+    def test_no_workspace_for_slack_com(self):
+        """slack.com URLの場合はワークスペースプロパティが設定されないこと"""
+        notion = NotionClient(api_key="test", db_id="db")
+        with patch("common.notion_client.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.ok = True
+            mock_resp.json.return_value = {"id": "page-1"}
+            mock_post.return_value = mock_resp
+
+            notion.create_violation_log(
+                post_content="test",
+                user_id="U1",
+                channel="C1",
+                result="Violation",
+                method="OpenAI",
+                post_link="https://slack.com/archives/C123/p111",
+            )
+
+            call_args = mock_post.call_args
+            props = call_args.kwargs["json"]["properties"]
+            assert "ワークスペース" not in props
+
+
+# ---- Reminder service functions ----
+
+class TestCheckMessageExists:
+    def test_message_exists(self):
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        assert check_message_exists(mock_slack, "C123", "1234567890.123456") is True
+
+    def test_message_deleted(self):
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {"messages": []}
+        assert check_message_exists(mock_slack, "C123", "1234567890.123456") is False
+
+    def test_different_ts(self):
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "9999999999.999999"}]
+        }
+        assert check_message_exists(mock_slack, "C123", "1234567890.123456") is False
+
+
+class TestSendWarning:
+    def test_success(self):
+        mock_slack = MagicMock()
+        text = "テスト警告文"
+        assert send_warning(mock_slack, "C123", "1234567890.123456", text) is True
+        mock_slack.chat_postMessage.assert_called_once_with(
+            channel="C123",
+            thread_ts="1234567890.123456",
+            text=text,
+        )
+
+    def test_failure(self):
+        from slack_sdk.errors import SlackApiError
+        mock_slack = MagicMock()
+        mock_slack.chat_postMessage.side_effect = SlackApiError(
+            message="error", response=MagicMock(status_code=403)
+        )
+        assert send_warning(mock_slack, "C123", "1234567890.123456", "text") is False
+
+
+class TestSendReminder:
+    def test_success(self):
+        mock_slack = MagicMock()
+        text = "テストリマインド文"
+        assert send_reminder(mock_slack, "C123", "1234567890.123456", text) is True
+        mock_slack.chat_postMessage.assert_called_once_with(
+            channel="C123",
+            thread_ts="1234567890.123456",
+            text=text,
+        )
+
+    def test_failure(self):
+        from slack_sdk.errors import SlackApiError
+        mock_slack = MagicMock()
+        mock_slack.chat_postMessage.side_effect = SlackApiError(
+            message="error", response=MagicMock(status_code=403)
+        )
+        assert send_reminder(mock_slack, "C123", "1234567890.123456", "text") is False
+
+
+class TestResolveSlackClient:
+    def test_known_workspace(self):
+        default = MagicMock()
+        ws_client = MagicMock()
+        result = _resolve_slack_client("myws", {"myws": ws_client}, default)
+        assert result is ws_client
+
+    def test_unknown_workspace(self):
+        default = MagicMock()
+        result = _resolve_slack_client("unknown", {"myws": MagicMock()}, default)
+        assert result is default
+
+    def test_none_workspace(self):
+        default = MagicMock()
+        result = _resolve_slack_client(None, {"myws": MagicMock()}, default)
+        assert result is default
+
+    def test_empty_clients(self):
+        default = MagicMock()
+        result = _resolve_slack_client("myws", {}, default)
+        assert result is default
+
+
+# ---- process_reminders integration ----
+
+class TestProcessReminders:
+    def _make_page(self, page_id="p1", link="https://ws.slack.com/archives/C123/p1234567890123456",
+                   warning_sent_at="USE_DEFAULT", has_warning=True):
+        """テスト用ページを作成。has_warning=Falseで警告送信日時なし（初回警告対象）"""
+        if warning_sent_at == "USE_DEFAULT":
+            warning_sent_at = (datetime.now(timezone.utc) - timedelta(hours=50)).isoformat()
+
+        warning_date = {"date": {"start": warning_sent_at}} if has_warning else {"date": None}
+
+        return {
+            "id": page_id,
+            "properties": {
+                "投稿リンク": {"url": link},
+                "警告送信日時": warning_date,
+                "投稿者": {"rich_text": [{"plain_text": "U_TEST"}]},
+                "投稿内容": {"title": [{"plain_text": "テスト投稿"}]},
+            },
+        }
+
+    def _setup_notion_mock(self, pages):
+        mock_notion = MagicMock(spec=NotionClient)
+        mock_notion.query_approved_unreminded.return_value = pages
+        mock_notion.extract_reminder_fields = NotionClient.extract_reminder_fields
+        mock_notion.is_past_threshold = NotionClient.is_past_threshold
+        mock_notion.parse_slack_link = NotionClient.parse_slack_link
+        mock_notion.mark_reminded.return_value = True
+        mock_notion.update_status.return_value = True
+        return mock_notion
+
+    def test_send_reminder(self):
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page()])
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["reminded"] == 1
+        mock_slack.chat_postMessage.assert_called_once()
+        mock_notion.mark_reminded.assert_called_once_with("p1")
+
+    def test_already_deleted(self):
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {"messages": []}
+        mock_notion = self._setup_notion_mock([self._make_page()])
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["already_deleted"] == 1
+        mock_slack.chat_postMessage.assert_not_called()
+        mock_notion.mark_reminded.assert_called_once()
+
+    def test_not_elapsed(self):
+        recent = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page(warning_sent_at=recent)])
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["skipped_not_elapsed"] == 1
+        mock_slack.chat_postMessage.assert_not_called()
+
+    def test_no_records(self):
+        mock_slack = MagicMock()
+        mock_notion = MagicMock(spec=NotionClient)
+        mock_notion.query_approved_unreminded.return_value = []
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion)
+
+        assert stats["queried"] == 0
+        mock_slack.chat_postMessage.assert_not_called()
+
+    def test_workspace_routing(self):
+        mock_default = MagicMock()
+        mock_ws = MagicMock()
+        mock_ws.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page()])
+
+        stats = process_reminders(
+            slack=mock_default,
+            notion=mock_notion,
+            hours_threshold=48,
+            slack_clients={"ws": mock_ws},
+        )
+
+        assert stats["reminded"] == 1
+        mock_ws.chat_postMessage.assert_called_once()
+        mock_default.chat_postMessage.assert_not_called()
+
+    def test_dry_run_reminder(self):
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page()])
+
+        stats = process_reminders(
+            slack=mock_slack, notion=mock_notion, hours_threshold=48, dry_run=True
+        )
+
+        assert stats["reminded"] == 1
+        mock_slack.chat_postMessage.assert_not_called()
+        mock_notion.mark_reminded.assert_not_called()
+
+    # ---- 初回警告テスト ----
+
+    def test_initial_warning_sent(self):
+        """警告送信日時なし → 初回警告を送信し、warning_sent_atを記録"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page(has_warning=False)])
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 1
+        assert stats["reminded"] == 0
+        mock_slack.chat_postMessage.assert_called_once_with(
+            channel="C123",
+            thread_ts="1234567890.123456",
+            text=FALLBACK_TEMPLATES["警告"],
+        )
+        mock_notion.update_status.assert_called_once()
+        call_args = mock_notion.update_status.call_args
+        assert call_args.args[0] == "p1"
+        assert call_args.args[1] == "Approved"
+        assert call_args.kwargs.get("warning_sent_at") is not None
+
+    def test_initial_warning_dry_run(self):
+        """dry_run=Trueの場合、初回警告は送信しない"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page(has_warning=False)])
+
+        stats = process_reminders(
+            slack=mock_slack, notion=mock_notion, hours_threshold=48, dry_run=True
+        )
+
+        assert stats["warned"] == 1
+        mock_slack.chat_postMessage.assert_not_called()
+        mock_notion.update_status.assert_not_called()
+
+    def test_initial_warning_message_deleted(self):
+        """警告送信日時なし + 投稿削除済み → 警告送信せず、mark_reminded"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {"messages": []}
+        mock_notion = self._setup_notion_mock([self._make_page(has_warning=False)])
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["already_deleted"] == 1
+        assert stats["warned"] == 0
+        mock_slack.chat_postMessage.assert_not_called()
+        mock_notion.mark_reminded.assert_called_once()
+
+    def test_mixed_warning_and_reminder(self):
+        """初回警告対象とリマインド対象が混在するケース"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        pages = [
+            self._make_page(page_id="p1", has_warning=False),
+            self._make_page(page_id="p2", has_warning=True),
+        ]
+        mock_notion = self._setup_notion_mock(pages)
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 1
+        assert stats["reminded"] == 1
+        assert mock_slack.chat_postMessage.call_count == 2
+
+    def test_article_relation_resolves_name(self):
+        """対象条文Relationから条文名が解決され、テンプレートに使用されること"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        page = self._make_page(has_warning=False)
+        page["properties"]["対象条文"] = {"relation": [{"id": "article-page-1"}]}
+        page["properties"]["該当条文"] = {"rich_text": [{"plain_text": "11-iv"}]}
+        mock_notion = self._setup_notion_mock([page])
+        mock_notion.get_article_name.return_value = "AI Community参加規約 第11条(iv)"
+
+        with patch("app_remind.services.reminder.resolve_template") as mock_resolve:
+            mock_resolve.return_value = "{{article}}に違反"
+            stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 1
+        # テンプレートに条文名が使用されていること
+        call_args = mock_slack.chat_postMessage.call_args
+        assert "AI Community参加規約 第11条(iv)に違反" in call_args.kwargs["text"]
+
+    def test_article_relation_fallback_to_rich_text(self):
+        """対象条文Relationが空の場合は該当条文(rich_text)にフォールバック"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        page = self._make_page(has_warning=False)
+        page["properties"]["対象条文"] = {"relation": []}
+        page["properties"]["該当条文"] = {"rich_text": [{"plain_text": "11-iv"}]}
+        mock_notion = self._setup_notion_mock([page])
+
+        with patch("app_remind.services.reminder.resolve_template") as mock_resolve:
+            mock_resolve.return_value = "{{article}}に違反"
+            stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 1
+        call_args = mock_slack.chat_postMessage.call_args
+        assert "11-ivに違反" in call_args.kwargs["text"]
+        mock_notion.get_article_name.assert_not_called()
+
+    def test_relation_template_used(self):
+        """Relation指定のテンプレートが使用されること"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        page = self._make_page(has_warning=False)
+        page["properties"]["使用テンプレート"] = {"relation": [{"id": "tmpl-page-1"}]}
+        mock_notion = self._setup_notion_mock([page])
+
+        custom_body = "カスタムテンプレートの本文です"
+        with patch("app_remind.services.reminder.resolve_template", return_value=custom_body):
+            stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 1
+        call_args = mock_slack.chat_postMessage.call_args
+        assert custom_body in call_args.kwargs["text"]
+
+
+# ---- Template manager: Relation対応 ----
+
+class TestResolveTemplateWithRelation:
+    @patch("common.template_manager.get_template_by_page_id")
+    def test_relation_takes_priority(self, mock_get_by_id):
+        """template_page_id指定時はRelationテンプレートが優先される"""
+        mock_get_by_id.return_value = "Relationテンプレート本文"
+        result = resolve_template("警告", api_key="key", db_id="db", template_page_id="tmpl-1")
+        assert result == "Relationテンプレート本文"
+        mock_get_by_id.assert_called_once_with("key", "tmpl-1")
+
+    @patch("common.template_manager.get_template_by_page_id")
+    @patch("common.template_manager.get_templates")
+    def test_fallback_to_db_when_relation_fails(self, mock_get_templates, mock_get_by_id):
+        """Relation取得失敗時はテンプレートDBにフォールバック"""
+        mock_get_by_id.return_value = None
+        mock_get_templates.return_value = {"警告": {"name": "標準", "body": "DB警告文"}}
+        result = resolve_template("警告", api_key="key", db_id="db", template_page_id="bad-id")
+        assert result == "DB警告文"
+
+    def test_fallback_to_hardcoded_when_no_relation(self):
+        """template_page_id空ならフォールバック"""
+        result = resolve_template("警告", template_page_id="")
+        assert result == FALLBACK_TEMPLATES["警告"]
+
+    @patch("common.template_manager.get_template_by_page_id")
+    def test_no_api_key_skips_relation(self, mock_get_by_id):
+        """api_keyなしの場合はRelation検索をスキップ"""
+        result = resolve_template("警告", api_key="", template_page_id="tmpl-1")
+        mock_get_by_id.assert_not_called()
+        assert result == FALLBACK_TEMPLATES["警告"]
+
+
+class TestFindArticlePageId:
+    def test_found(self):
+        """条文IDからpage_idを取得"""
+        notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
+        with patch("common.notion_client.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.ok = True
+            mock_resp.json.return_value = {
+                "results": [{"id": "article-page-1"}]
+            }
+            mock_post.return_value = mock_resp
+
+            result = notion.find_article_page_id("11-iv")
+            assert result == "article-page-1"
+
+    def test_not_found(self):
+        """条文IDが見つからない場合はNone"""
+        notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
+        with patch("common.notion_client.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.ok = True
+            mock_resp.json.return_value = {"results": []}
+            mock_post.return_value = mock_resp
+
+            result = notion.find_article_page_id("nonexistent")
+            assert result is None
+
+    def test_no_articles_db_id(self):
+        """articles_db_id未設定の場合はNone"""
+        notion = NotionClient(api_key="test", db_id="db")
+        result = notion.find_article_page_id("11-iv")
+        assert result is None
+
+    def test_empty_article_id(self):
+        """空のarticle_idの場合はNone"""
+        notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
+        result = notion.find_article_page_id("")
+        assert result is None
+
+
+class TestGetArticleName:
+    @patch("common.notion_client.requests.get")
+    def test_returns_article_number(self, mock_get):
+        """条項番号から条文名を取得"""
+        notion = NotionClient(api_key="test", db_id="db")
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "properties": {
+                "条文ID": {"title": [{"plain_text": "11-iv"}]},
+                "条項番号": {"rich_text": [{"plain_text": "AI Community参加規約 第11条(iv)"}]},
+            }
+        }
+        mock_get.return_value = mock_resp
+
+        result = notion.get_article_name("article-page-1")
+        assert result == "AI Community参加規約 第11条(iv)"
+
+    @patch("common.notion_client.requests.get")
+    def test_fallback_to_title(self, mock_get):
+        """条項番号が空の場合はタイトル（条文ID）にフォールバック"""
+        notion = NotionClient(api_key="test", db_id="db")
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "properties": {
+                "条文ID": {"title": [{"plain_text": "11-iv"}]},
+                "条項番号": {"rich_text": []},
+            }
+        }
+        mock_get.return_value = mock_resp
+
+        result = notion.get_article_name("article-page-1")
+        assert result == "11-iv"
+
+    @patch("common.notion_client.requests.get")
+    def test_api_failure_returns_none(self, mock_get):
+        """API失敗時はNone"""
+        notion = NotionClient(api_key="test", db_id="db")
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = notion.get_article_name("bad-page")
+        assert result is None
+
+
+class TestGetTemplateByPageId:
+    @patch("common.template_manager.requests.get")
+    def test_success(self, mock_get):
+        """ページIDからテンプレート本文を取得"""
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "properties": {
+                "テンプレート名": {"title": [{"plain_text": "カスタム警告"}]},
+                "用途": {"select": {"name": "警告"}},
+                "本文": {"rich_text": [{"plain_text": "カスタム本文"}]},
+            }
+        }
+        mock_get.return_value = mock_resp
+
+        result = get_template_by_page_id("api-key", "page-123")
+        assert result == "カスタム本文"
+
+    @patch("common.template_manager.requests.get")
+    def test_api_failure_returns_none(self, mock_get):
+        """API失敗時はNoneを返す"""
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = get_template_by_page_id("api-key", "bad-page")
+        assert result is None
+
+    @patch("common.template_manager.requests.get")
+    def test_empty_body_returns_none(self, mock_get):
+        """本文が空の場合はNoneを返す"""
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "properties": {
+                "テンプレート名": {"title": [{"plain_text": "空テンプレ"}]},
+                "用途": {"select": {"name": "警告"}},
+                "本文": {"rich_text": []},
+            }
+        }
+        mock_get.return_value = mock_resp
+
+        result = get_template_by_page_id("api-key", "page-456")
+        assert result is None

--- a/tests/unit/test_app_remind.py
+++ b/tests/unit/test_app_remind.py
@@ -9,7 +9,6 @@ from common.notion_client import NotionClient
 from app_remind.services.reminder import (
     check_message_exists,
     send_warning,
-    send_reminder,
     process_reminders,
     _resolve_slack_client,
 )
@@ -69,7 +68,6 @@ class TestExtractReminderFields:
         assert fields["article_id"] == "第3条"
 
     def test_no_warning_sent_at_returns_none(self):
-        """警告送信日時が空の場合、フォールバックなしでNoneを返す"""
         page = {
             "id": "page-456",
             "last_edited_time": "2026-01-15T12:00:00.000Z",
@@ -109,7 +107,6 @@ class TestExtractReminderFields:
         assert fields["template_page_id"] == ""
 
     def test_relation_template(self):
-        """使用テンプレートRelationからpage_idを抽出"""
         page = {
             "id": "p",
             "properties": {
@@ -124,7 +121,6 @@ class TestExtractReminderFields:
         assert fields["template_page_id"] == "tmpl-page-123"
 
     def test_relation_empty(self):
-        """使用テンプレートRelationが未設定の場合は空文字"""
         page = {
             "id": "p",
             "properties": {
@@ -139,7 +135,6 @@ class TestExtractReminderFields:
         assert fields["template_page_id"] == ""
 
     def test_article_relation(self):
-        """対象条文Relationからpage_idを抽出"""
         page = {
             "id": "p",
             "properties": {
@@ -154,7 +149,6 @@ class TestExtractReminderFields:
         assert fields["article_page_id"] == "article-page-1"
 
     def test_article_relation_empty(self):
-        """対象条文Relationが未設定の場合は空文字"""
         page = {
             "id": "p",
             "properties": {
@@ -197,7 +191,6 @@ class TestIsPastThreshold:
 
 class TestWorkspaceProperty:
     def test_workspace_set_from_post_link(self):
-        """create_violation_log がワークスペースプロパティを設定すること"""
         notion = NotionClient(api_key="test", db_id="db")
         with patch("common.notion_client.requests.post") as mock_post:
             mock_resp = MagicMock()
@@ -219,7 +212,6 @@ class TestWorkspaceProperty:
             assert props["ワークスペース"] == {"select": {"name": "myws"}}
 
     def test_article_relation_set_from_article_id(self):
-        """article_idが指定されたとき、対象条文Relationが設定されること"""
         notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
         with patch("common.notion_client.requests.post") as mock_post:
             mock_resp = MagicMock()
@@ -243,7 +235,6 @@ class TestWorkspaceProperty:
             assert props["対象条文"] == {"relation": [{"id": "article-page-123"}]}
 
     def test_article_relation_not_set_when_not_found(self):
-        """articles_dbにarticle_idが見つからない場合はRelation設定されないこと"""
         notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
         with patch("common.notion_client.requests.post") as mock_post:
             mock_resp = MagicMock()
@@ -267,7 +258,6 @@ class TestWorkspaceProperty:
             assert "対象条文" not in props
 
     def test_no_workspace_for_slack_com(self):
-        """slack.com URLの場合はワークスペースプロパティが設定されないこと"""
         notion = NotionClient(api_key="test", db_id="db")
         with patch("common.notion_client.requests.post") as mock_post:
             mock_resp = MagicMock()
@@ -332,26 +322,6 @@ class TestSendWarning:
         assert send_warning(mock_slack, "C123", "1234567890.123456", "text") is False
 
 
-class TestSendReminder:
-    def test_success(self):
-        mock_slack = MagicMock()
-        text = "テストリマインド文"
-        assert send_reminder(mock_slack, "C123", "1234567890.123456", text) is True
-        mock_slack.chat_postMessage.assert_called_once_with(
-            channel="C123",
-            thread_ts="1234567890.123456",
-            text=text,
-        )
-
-    def test_failure(self):
-        from slack_sdk.errors import SlackApiError
-        mock_slack = MagicMock()
-        mock_slack.chat_postMessage.side_effect = SlackApiError(
-            message="error", response=MagicMock(status_code=403)
-        )
-        assert send_reminder(mock_slack, "C123", "1234567890.123456", "text") is False
-
-
 class TestResolveSlackClient:
     def test_known_workspace(self):
         default = MagicMock()
@@ -380,7 +350,6 @@ class TestResolveSlackClient:
 class TestProcessReminders:
     def _make_page(self, page_id="p1", link="https://ws.slack.com/archives/C123/p1234567890123456",
                    warning_sent_at="USE_DEFAULT", has_warning=True):
-        """テスト用ページを作成。has_warning=Falseで警告送信日時なし（初回警告対象）"""
         if warning_sent_at == "USE_DEFAULT":
             warning_sent_at = (datetime.now(timezone.utc) - timedelta(hours=50)).isoformat()
 
@@ -404,9 +373,14 @@ class TestProcessReminders:
         mock_notion.parse_slack_link = NotionClient.parse_slack_link
         mock_notion.mark_reminded.return_value = True
         mock_notion.update_status.return_value = True
+        # get_page: デフォルトではページをそのまま返す（再取得でも同じ状態）
+        mock_notion.get_page.side_effect = lambda pid: next(
+            (p for p in pages if p["id"] == pid), None
+        )
         return mock_notion
 
-    def test_send_reminder(self):
+    def test_48h_reminder_notion_only(self):
+        """48h経過 → Notionでmark_reminded、Slack送信なし"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {
             "messages": [{"ts": "1234567890.123456"}]
@@ -416,8 +390,8 @@ class TestProcessReminders:
         stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
 
         assert stats["reminded"] == 1
-        mock_slack.chat_postMessage.assert_called_once()
         mock_notion.mark_reminded.assert_called_once_with("p1")
+        mock_slack.chat_postMessage.assert_not_called()
 
     def test_already_deleted(self):
         mock_slack = MagicMock()
@@ -454,6 +428,7 @@ class TestProcessReminders:
         mock_slack.chat_postMessage.assert_not_called()
 
     def test_workspace_routing(self):
+        """ワークスペース別クライアントは存在確認に使用"""
         mock_default = MagicMock()
         mock_ws = MagicMock()
         mock_ws.conversations_history.return_value = {
@@ -469,8 +444,9 @@ class TestProcessReminders:
         )
 
         assert stats["reminded"] == 1
-        mock_ws.chat_postMessage.assert_called_once()
+        mock_ws.conversations_history.assert_called_once()
         mock_default.chat_postMessage.assert_not_called()
+        mock_ws.chat_postMessage.assert_not_called()
 
     def test_dry_run_reminder(self):
         mock_slack = MagicMock()
@@ -480,7 +456,7 @@ class TestProcessReminders:
         mock_notion = self._setup_notion_mock([self._make_page()])
 
         stats = process_reminders(
-            slack=mock_slack, notion=mock_notion, hours_threshold=48, dry_run=True
+            slack=mock_slack, notion=mock_notion, hours_threshold=48, dry_run=True,
         )
 
         assert stats["reminded"] == 1
@@ -489,8 +465,8 @@ class TestProcessReminders:
 
     # ---- 初回警告テスト ----
 
-    def test_initial_warning_sent(self):
-        """警告送信日時なし → 初回警告を送信し、warning_sent_atを記録"""
+    def test_initial_warning_sent_to_thread(self):
+        """警告送信日時なし → 違反投稿スレッドに初回警告"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {
             "messages": [{"ts": "1234567890.123456"}]
@@ -501,19 +477,30 @@ class TestProcessReminders:
 
         assert stats["warned"] == 1
         assert stats["reminded"] == 0
-        mock_slack.chat_postMessage.assert_called_once_with(
-            channel="C123",
-            thread_ts="1234567890.123456",
-            text=FALLBACK_TEMPLATES["警告"],
-        )
+        mock_slack.chat_postMessage.assert_called_once()
+        call_args = mock_slack.chat_postMessage.call_args
+        assert call_args.kwargs["channel"] == "C123"
+        assert call_args.kwargs["thread_ts"] == "1234567890.123456"
         mock_notion.update_status.assert_called_once()
-        call_args = mock_notion.update_status.call_args
-        assert call_args.args[0] == "p1"
-        assert call_args.args[1] == "Approved"
-        assert call_args.kwargs.get("warning_sent_at") is not None
+        assert mock_notion.update_status.call_args.args[0] == "p1"
+        assert mock_notion.update_status.call_args.args[1] == "Approved"
+        assert mock_notion.update_status.call_args.kwargs.get("warning_sent_at") is not None
+
+    def test_initial_warning_uses_fallback_template(self):
+        """初回警告はテンプレート（フォールバック）を使用"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        mock_notion = self._setup_notion_mock([self._make_page(has_warning=False)])
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 1
+        call_args = mock_slack.chat_postMessage.call_args
+        assert call_args.kwargs["text"] == FALLBACK_TEMPLATES["警告"]
 
     def test_initial_warning_dry_run(self):
-        """dry_run=Trueの場合、初回警告は送信しない"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {
             "messages": [{"ts": "1234567890.123456"}]
@@ -521,7 +508,7 @@ class TestProcessReminders:
         mock_notion = self._setup_notion_mock([self._make_page(has_warning=False)])
 
         stats = process_reminders(
-            slack=mock_slack, notion=mock_notion, hours_threshold=48, dry_run=True
+            slack=mock_slack, notion=mock_notion, hours_threshold=48, dry_run=True,
         )
 
         assert stats["warned"] == 1
@@ -529,7 +516,6 @@ class TestProcessReminders:
         mock_notion.update_status.assert_not_called()
 
     def test_initial_warning_message_deleted(self):
-        """警告送信日時なし + 投稿削除済み → 警告送信せず、mark_reminded"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {"messages": []}
         mock_notion = self._setup_notion_mock([self._make_page(has_warning=False)])
@@ -542,7 +528,7 @@ class TestProcessReminders:
         mock_notion.mark_reminded.assert_called_once()
 
     def test_mixed_warning_and_reminder(self):
-        """初回警告対象とリマインド対象が混在するケース"""
+        """初回警告対象とリマインド対象が混在"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {
             "messages": [{"ts": "1234567890.123456"}]
@@ -557,10 +543,31 @@ class TestProcessReminders:
 
         assert stats["warned"] == 1
         assert stats["reminded"] == 1
-        assert mock_slack.chat_postMessage.call_count == 2
+        # 初回警告のみSlack送信、48hリマインドはNotion更新のみ
+        mock_slack.chat_postMessage.assert_called_once()
+        call_args = mock_slack.chat_postMessage.call_args
+        assert call_args.kwargs["thread_ts"] == "1234567890.123456"
+
+    def test_initial_warning_skipped_when_lambda_b_already_warned(self):
+        """Lambda Bが先に警告済み → Lambda Cはスキップ（競合防止）"""
+        mock_slack = MagicMock()
+        mock_slack.conversations_history.return_value = {
+            "messages": [{"ts": "1234567890.123456"}]
+        }
+        page = self._make_page(has_warning=False)
+        mock_notion = self._setup_notion_mock([page])
+        # get_page で再取得すると warning_sent_at がセットされている（Lambda Bが処理済み）
+        fresh_page = self._make_page(has_warning=True)
+        fresh_page["id"] = "p1"
+        mock_notion.get_page.side_effect = lambda pid: fresh_page
+
+        stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
+
+        assert stats["warned"] == 0
+        assert stats["skipped_not_elapsed"] == 1
+        mock_slack.chat_postMessage.assert_not_called()
 
     def test_article_relation_resolves_name(self):
-        """対象条文Relationから条文名が解決され、テンプレートに使用されること"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {
             "messages": [{"ts": "1234567890.123456"}]
@@ -576,12 +583,10 @@ class TestProcessReminders:
             stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
 
         assert stats["warned"] == 1
-        # テンプレートに条文名が使用されていること
         call_args = mock_slack.chat_postMessage.call_args
         assert "AI Community参加規約 第11条(iv)に違反" in call_args.kwargs["text"]
 
     def test_article_relation_fallback_to_rich_text(self):
-        """対象条文Relationが空の場合は該当条文(rich_text)にフォールバック"""
         mock_slack = MagicMock()
         mock_slack.conversations_history.return_value = {
             "messages": [{"ts": "1234567890.123456"}]
@@ -600,31 +605,12 @@ class TestProcessReminders:
         assert "11-ivに違反" in call_args.kwargs["text"]
         mock_notion.get_article_name.assert_not_called()
 
-    def test_relation_template_used(self):
-        """Relation指定のテンプレートが使用されること"""
-        mock_slack = MagicMock()
-        mock_slack.conversations_history.return_value = {
-            "messages": [{"ts": "1234567890.123456"}]
-        }
-        page = self._make_page(has_warning=False)
-        page["properties"]["使用テンプレート"] = {"relation": [{"id": "tmpl-page-1"}]}
-        mock_notion = self._setup_notion_mock([page])
-
-        custom_body = "カスタムテンプレートの本文です"
-        with patch("app_remind.services.reminder.resolve_template", return_value=custom_body):
-            stats = process_reminders(slack=mock_slack, notion=mock_notion, hours_threshold=48)
-
-        assert stats["warned"] == 1
-        call_args = mock_slack.chat_postMessage.call_args
-        assert custom_body in call_args.kwargs["text"]
-
 
 # ---- Template manager: Relation対応 ----
 
 class TestResolveTemplateWithRelation:
     @patch("common.template_manager.get_template_by_page_id")
     def test_relation_takes_priority(self, mock_get_by_id):
-        """template_page_id指定時はRelationテンプレートが優先される"""
         mock_get_by_id.return_value = "Relationテンプレート本文"
         result = resolve_template("警告", api_key="key", db_id="db", template_page_id="tmpl-1")
         assert result == "Relationテンプレート本文"
@@ -633,20 +619,17 @@ class TestResolveTemplateWithRelation:
     @patch("common.template_manager.get_template_by_page_id")
     @patch("common.template_manager.get_templates")
     def test_fallback_to_db_when_relation_fails(self, mock_get_templates, mock_get_by_id):
-        """Relation取得失敗時はテンプレートDBにフォールバック"""
         mock_get_by_id.return_value = None
         mock_get_templates.return_value = {"警告": {"name": "標準", "body": "DB警告文"}}
         result = resolve_template("警告", api_key="key", db_id="db", template_page_id="bad-id")
         assert result == "DB警告文"
 
     def test_fallback_to_hardcoded_when_no_relation(self):
-        """template_page_id空ならフォールバック"""
         result = resolve_template("警告", template_page_id="")
         assert result == FALLBACK_TEMPLATES["警告"]
 
     @patch("common.template_manager.get_template_by_page_id")
     def test_no_api_key_skips_relation(self, mock_get_by_id):
-        """api_keyなしの場合はRelation検索をスキップ"""
         result = resolve_template("警告", api_key="", template_page_id="tmpl-1")
         mock_get_by_id.assert_not_called()
         assert result == FALLBACK_TEMPLATES["警告"]
@@ -654,39 +637,31 @@ class TestResolveTemplateWithRelation:
 
 class TestFindArticlePageId:
     def test_found(self):
-        """条文IDからpage_idを取得"""
         notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
         with patch("common.notion_client.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.ok = True
-            mock_resp.json.return_value = {
-                "results": [{"id": "article-page-1"}]
-            }
+            mock_resp.json.return_value = {"results": [{"id": "article-page-1"}]}
             mock_post.return_value = mock_resp
-
             result = notion.find_article_page_id("11-iv")
             assert result == "article-page-1"
 
     def test_not_found(self):
-        """条文IDが見つからない場合はNone"""
         notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
         with patch("common.notion_client.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.ok = True
             mock_resp.json.return_value = {"results": []}
             mock_post.return_value = mock_resp
-
             result = notion.find_article_page_id("nonexistent")
             assert result is None
 
     def test_no_articles_db_id(self):
-        """articles_db_id未設定の場合はNone"""
         notion = NotionClient(api_key="test", db_id="db")
         result = notion.find_article_page_id("11-iv")
         assert result is None
 
     def test_empty_article_id(self):
-        """空のarticle_idの場合はNone"""
         notion = NotionClient(api_key="test", db_id="db", articles_db_id="articles-db")
         result = notion.find_article_page_id("")
         assert result is None
@@ -695,7 +670,6 @@ class TestFindArticlePageId:
 class TestGetArticleName:
     @patch("common.notion_client.requests.get")
     def test_returns_article_number(self, mock_get):
-        """条項番号から条文名を取得"""
         notion = NotionClient(api_key="test", db_id="db")
         mock_resp = MagicMock()
         mock_resp.ok = True
@@ -706,13 +680,11 @@ class TestGetArticleName:
             }
         }
         mock_get.return_value = mock_resp
-
         result = notion.get_article_name("article-page-1")
         assert result == "AI Community参加規約 第11条(iv)"
 
     @patch("common.notion_client.requests.get")
     def test_fallback_to_title(self, mock_get):
-        """条項番号が空の場合はタイトル（条文ID）にフォールバック"""
         notion = NotionClient(api_key="test", db_id="db")
         mock_resp = MagicMock()
         mock_resp.ok = True
@@ -723,19 +695,16 @@ class TestGetArticleName:
             }
         }
         mock_get.return_value = mock_resp
-
         result = notion.get_article_name("article-page-1")
         assert result == "11-iv"
 
     @patch("common.notion_client.requests.get")
     def test_api_failure_returns_none(self, mock_get):
-        """API失敗時はNone"""
         notion = NotionClient(api_key="test", db_id="db")
         mock_resp = MagicMock()
         mock_resp.ok = False
         mock_resp.status_code = 404
         mock_get.return_value = mock_resp
-
         result = notion.get_article_name("bad-page")
         assert result is None
 
@@ -743,7 +712,6 @@ class TestGetArticleName:
 class TestGetTemplateByPageId:
     @patch("common.template_manager.requests.get")
     def test_success(self, mock_get):
-        """ページIDからテンプレート本文を取得"""
         mock_resp = MagicMock()
         mock_resp.ok = True
         mock_resp.json.return_value = {
@@ -754,24 +722,20 @@ class TestGetTemplateByPageId:
             }
         }
         mock_get.return_value = mock_resp
-
         result = get_template_by_page_id("api-key", "page-123")
         assert result == "カスタム本文"
 
     @patch("common.template_manager.requests.get")
     def test_api_failure_returns_none(self, mock_get):
-        """API失敗時はNoneを返す"""
         mock_resp = MagicMock()
         mock_resp.ok = False
         mock_resp.status_code = 404
         mock_get.return_value = mock_resp
-
         result = get_template_by_page_id("api-key", "bad-page")
         assert result is None
 
     @patch("common.template_manager.requests.get")
     def test_empty_body_returns_none(self, mock_get):
-        """本文が空の場合はNoneを返す"""
         mock_resp = MagicMock()
         mock_resp.ok = True
         mock_resp.json.return_value = {
@@ -782,6 +746,5 @@ class TestGetTemplateByPageId:
             }
         }
         mock_get.return_value = mock_resp
-
         result = get_template_by_page_id("api-key", "page-456")
         assert result is None


### PR DESCRIPTION
## Summary
Lambda C: EventBridgeポーリングで未処理レコードを補完
- 初回警告（warning_sent_at空）→ スレッド送信 + 競合防止（Notion再取得）
- 48h経過 → Notion上でmark_remindedのみ（Slack送信なし）

Lambda A/B: NotionテンプレートDBとの連携
- A: 管理者通知にテンプレート選択プルダウン追加、条文Relation自動設定
- B: 選択テンプレートでの警告文解決、プレースホルダー置換対応
- common: template_manager / notion_client拡張

※ main側のマルチWS対応（PR #28）とのコンフリクト解消済み