### PR TITLE
feat: 重複ログ防止のためMessage_TS列を新設し、投稿内容からタイムスタンプ表示を削除

### DIFF
--- a/contracts/specs/notion_db_schema.md
+++ b/contracts/specs/notion_db_schema.md
@@ -30,6 +30,8 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 | **リマインド送信済** | Checkbox     | NO   | 削除依頼リマインド送信後にtrueにする。<br>Lambda C（将来実装）用。                   | -                                                                                                 |
 | **違反理由**         | RichText     | NO   | 違反と判定された理由の詳細（AIの出力）。                                             | -                                                                                                 |
 | **違反カテゴリ**     | Multi-select | NO   | 該当する違反のカテゴリ。                                                             | -                                                                                                 |
+| **Message_TS**       | RichText     | NO   | 重複チェック用のSlackタイムスタンプ                                                  | -                                                                                                 |
+|  |
 | **重大度**           | Select       | NO   | 違反の重大度。                                                                       | **Options**:<br>- `low`<br>- `medium`<br>- `high`                                                 |
 
     - **Write**: Lambda A (app_inspect) - 新規作成

--- a/lambda/common/notion_client.py
+++ b/lambda/common/notion_client.py
@@ -47,9 +47,9 @@ class NotionClient:
             return False
         try:
             results = self._query({
-                "property": "投稿内容",
-                "title": {"starts_with": f"{message_ts}:"}
-            })
+            "property": "Message_TS",
+            "rich_text": {"equals": message_ts}
+        })
             return len(results) > 0
         except Exception as e:
             logger.error(f"Duplicate check failed: {e}")
@@ -78,7 +78,7 @@ class NotionClient:
         # タイトルにmessage_tsを含めて重複チェック可能に
         content_preview = post_content[:80]
         if message_ts:
-            title = f"{message_ts}: {content_preview}"
+            props["Message_TS"] = {"rich_text": [{"text": {"content": message_ts}}]}
         else:
             title = content_preview[:100]
 


### PR DESCRIPTION
NotionのUI改善（タイトルのプレフィックス削除）とシステム堅牢性（重複ログの防止）を両立させるため、NotionDBに『Message_TS』列を新設し、検索キーをそちらに変更するアーキテクチャ改修を行いました。仕様書も更新済みです。レビューをお願いします。