### PR TITLE
fix: Notionの対応ステータス更新エラー修正、および対応者をIDから表示名へ変更

### DIFF
--- a/lambda/app_alert/handler.py
+++ b/lambda/app_alert/handler.py
@@ -49,9 +49,12 @@ def lambda_handler(event: dict, context: Any) -> dict:
 
         # 対応者（ボタン押下者）
         responder_id = None
+        responder_name = None  # Notion記録用の名前を格納する変数
         user_info = payload.get("user")
         if isinstance(user_info, dict):
             responder_id = user_info.get("id")
+            # Slackのペイロードからユーザー名を抽出。取得できない場合の保険としてIDを入れる
+            responder_name = user_info.get("name") or user_info.get("username") or responder_id
 
         if not action_context or not action_context.action_id:
             log_info(context, action="ignore_action", reason="no_action_id")
@@ -78,6 +81,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 notion=notion,
                 reply_text=cfg.reply_prefix,
                 responder_id=responder_id,
+                responder_name=responder_name,
             )
 
         elif action_context.action_id == "dismiss_violation":
@@ -88,6 +92,7 @@ def lambda_handler(event: dict, context: Any) -> dict:
                 slack=slack,
                 notion=notion,
                 responder_id=responder_id,
+                responder_name=responder_name,
             )
 
         if success:

--- a/lambda/app_alert/services/actions.py
+++ b/lambda/app_alert/services/actions.py
@@ -134,6 +134,7 @@ def handle_approve_violation(
     notion: "NotionClient",
     reply_text: str,
     responder_id: str | None = None,
+    responder_name: str | None = None,
 ) -> bool:
     origin_channel = context.value.get("origin_channel")
     origin_ts = context.value.get("origin_ts")
@@ -157,8 +158,10 @@ def handle_approve_violation(
         if notion_page_id:
             update_kwargs: dict[str, Any] = {}
             update_kwargs["warning_sent_at"] = datetime.now()  # 既存挙動のまま
-            if responder_id:
-                update_kwargs["responder_id"] = responder_id
+            if responder_name:
+                update_kwargs["responder_id"] = responder_name
+            elif responder_id:
+                update_kwargs["responder_id"] = responder_id # 万が一名前が取れなかった時の保険
             notion.update_status(notion_page_id, "Approved", **update_kwargs)
             logger.info(f"Updated Notion {notion_page_id} to Approved")
 

--- a/lambda/app_alert/services/actions.py
+++ b/lambda/app_alert/services/actions.py
@@ -192,13 +192,17 @@ def handle_dismiss_violation(
     slack: "WebClient",
     notion: "NotionClient",
     responder_id: str | None = None,
+    responder_name: str | None = None,
 ) -> bool:
     notion_page_id = context.value.get("notion_page_id")
 
     try:
         if notion_page_id:
             update_kwargs: dict[str, Any] = {}
-            if responder_id:
+            # NotionへはSlackのIDではなく、表示名（responder_name）を渡す
+            if responder_name:
+                update_kwargs["responder_id"] = responder_name
+            elif responder_id:
                 update_kwargs["responder_id"] = responder_id
             notion.update_status(notion_page_id, "Dismissed", **update_kwargs)
             logger.info(f"Updated Notion {notion_page_id} to Dismissed")


### PR DESCRIPTION
## 概要
Slackのボタン押下時にNotionの「対応ステータス」が更新されない不具合の根本解決、および対応者（Responder）の視認性向上を目的としたアーキテクチャ改修とコード修正を行いました。

## 原因と課題
1. **ステータス更新エラー（沈黙の失敗）**: 
   コード側（`notion_client.py`）で「警告送信日時」「対応者」をNotionに送信する仕様になっていたが、Notionのデータベース側にそのプロパティ（列）が存在しなかったため、Notion APIでエラーが発生し更新が弾かれていた。
2. **対応者の可読性欠如**: 
   SlackのInteractive Payloadから `user.id` のみを抽出しNotionに送信していたため、対応者が無機質なID（例: U0123ABCD）で記録され、運用担当者が「誰が承認したか」を直感的に把握できない状態だった。

## 変更内容
- **Notion DBのスキーマ拡張**: 「違反ログv2」データベースに「警告送信日時 (Date)」「対応者 (Text)」の2列を新設（していただいた）。
- **仕様書の同期**: `contracts/specs/notion_db_schema.md` に新設した2つのプロパティ定義を追記。
- **ハンドラーの抽出ロジック改修 (`lambda/app_alert/handler.py`)**: Slackペイロードの `user` オブジェクトから、IDだけでなく `name` または `username` （表示名）を抽出する処理を追加。
- **アクションの引数・更新ロジック改修 (`lambda/app_alert/services/actions.py`)**: `handle_approve_violation` および `handle_dismiss_violation` の引数に `responder_name` を追加し、Notion APIへの更新リクエストに表示名を渡すようロジックを変更（取得不能時のフォールバックとしてIDを使用）。

## 確認手順（レビュアー・デプロイ後の検証フロー）
1. 本PRマージ後、GitHub Actionsより `main` ブランチの Manual Deploy(CD) を実行。
2. Slackの監視対象チャンネルにてテスト用の違反検知を発生させ、「Approve」または「Dismiss」ボタンを押下。
3. Notionの当該ログにて以下3点が満たされていることを確認：
   - 「対応ステータス」が `Approved` または `Dismissed` に遷移していること。
   - 「対応者」列に、英数字のIDではなく「Slackのユーザー名（表示名）」が印字されていること。
   - 「警告送信日時」が正しく記録されていること。