### PR TITLE
feat: CDKにLambda D (app_remind) + EventBridgeスケジュール追加

### DIFF
--- a/contracts/specs/notion_db_schema.md
+++ b/contracts/specs/notion_db_schema.md
@@ -9,13 +9,14 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 - **System**:
   - **Write**: Lambda A (app_inspect) - 新規作成
   - **Update**: Lambda B (app_alert) - ステータス更新
+  - **Update**: Lambda D (app_remind) - 警告送信・48h経過・リマインド送信
 
 ## プロパティ定義
 
 | プロパティ名         | タイプ       | 必須 | 説明                                                                                 | 選択肢 / 設定                                                                                     |
 | :------------------- | :----------- | :--- | :----------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
 | **投稿内容**         | Title        | YES  | 投稿内容の抜粋（検索・見出し用）。<br>※文字数制限あり（100文字推奨）                 | -                                                                                                 |
-| **対応ステータス**   | Select       | YES  | 対応状況。<br>Lambda Bによりボタン操作で更新される。                                 | **Options**:<br>- `Unprocessed` (初期値)<br>- `Approved` (警告送信済)<br>- `Dismissed` (対応不要) |
+| **対応ステータス**   | Select       | YES  | 対応状況。<br>Lambda B/Dにより更新される。                                           | **Options**:<br>- `Unprocessed` (初期値)<br>- `Approved` (警告送信済)<br>- `Dismissed` (対応不要)<br>- `48h_Over` (警告後48h経過)<br>- `Remind_Requested` (運営がリマインド依頼)<br>- `Reminded` (リマインド送信完了) |
 | **判定結果**         | Select       | YES  | 違反判定の結果カテゴリ。                                                             | **Options**:<br>- `Violation`<br>- `Safe`<br>etc.                                                 |
 | **検出方法**         | Select       | YES  | 検知に使用した手法。                                                                 | **Options**:<br>- `OpenAI`<br>- `NGWord`                                                          |
 | **信頼度**           | Number       | NO   | AI判定の信頼度（0.0 - 1.0）。                                                        | 表示形式: `Percent`                                                                               |
@@ -27,33 +28,15 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 | **検出日時**         | Date         | YES  | 検知日時（ISO 8601）。                                                               | -                                                                                                 |
 | **対応者**           | RichText     | NO   | ボタンを押した管理者のSlack User ID。<br>Lambda Bにより記録される。                  | -                                                                                                 |
 | **警告送信日時**     | Date         | NO   | 警告送信が実行された日時（ISO 8601）。<br>Lambda Bにより `Approved` 時に記録される。 | -                                                                                                 |
-| **リマインド送信済** | Checkbox     | NO   | 削除依頼リマインド送信後にtrueにする。<br>Lambda C（将来実装）用。                   | -                                                                                                 |
 | **違反理由**         | RichText     | NO   | 違反と判定された理由の詳細（AIの出力）。                                             | -                                                                                                 |
 | **違反カテゴリ**     | Multi-select | NO   | 該当する違反のカテゴリ。                                                             | -                                                                                                 |
 | **Message_TS**       | RichText     | NO   | 重複チェック用のSlackタイムスタンプ                                                  | -                                                                                                 |
 |  |
 | **重大度**           | Select       | NO   | 違反の重大度。                                                                       | **Options**:<br>- `low`<br>- `medium`<br>- `high`                                                 |
 
-    - **Write**: Lambda A (app_inspect) - 新規作成
-    - **Update**: Lambda B (app_alert) - ステータス更新
-
-## プロパティ定義
-
-| プロパティ名         | タイプ   | 必須 | 説明                                                                                 | 選択肢 / 設定                                                                                     |
-| :------------------- | :------- | :--- | :----------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
-| **投稿内容**         | Title    | YES  | 投稿内容の抜粋（検索・見出し用）。<br>※文字数制限あり（100文字推奨）                 | -                                                                                                 |
-| **対応ステータス**   | Select   | YES  | 対応状況。<br>Lambda Bによりボタン操作で更新される。                                 | **Options**:<br>- `Unprocessed` (初期値)<br>- `Approved` (警告送信済)<br>- `Dismissed` (対応不要) |
-| **判定結果**         | Select   | YES  | 違反判定の結果カテゴリ。                                                             | **Options**:<br>- `Violation`<br>- `Safe`<br>etc.                                                 |
-| **検出方法**         | Select   | YES  | 検知に使用した手法。                                                                 | **Options**:<br>- `OpenAI`<br>- `NGWord`                                                          |
-| **信頼度**           | Number   | NO   | AI判定の信頼度（0.0 - 1.0）。                                                        | 表示形式: `Percent`                                                                               |
-| **該当条文**         | RichText | NO   | 違反と判定された根拠となる条文ID。<br>Feat版機能の復活項目。                         | -                                                                                                 |
-| **投稿者**           | RichText | YES  | 投稿者のSlack User ID（または表示名）。                                              | -                                                                                                 |
-| **チャンネル**       | RichText | YES  | 投稿されたチャンネル名/ID。                                                          | -                                                                                                 |
-| **投稿リンク**       | URL      | YES  | Slackの元投稿へのPermlink。                                                          | -                                                                                                 |
-| **検出日時**         | Date     | YES  | 検知日時（ISO 8601）。                                                               | -                                                                                                 |
-| **対応者**           | RichText | NO   | ボタンを押した管理者のSlack User ID。<br>Lambda Bにより記録される。                  | -                                                                                                 |
-| **警告送信日時**     | Date     | NO   | 警告送信が実行された日時（ISO 8601）。<br>Lambda Bにより `Approved` 時に記録される。 | -                                                                                                 |
-| **リマインド送信済** | Checkbox | NO   | 削除依頼リマインド送信後にtrueにする。<br>Lambda C（将来実装）用。                   | -                                                                                                 |
+| **追加メッセージ**   | RichText     | NO   | テンプレート末尾に付加するカスタムメッセージ。                                       | -                                                                                                 |
+| **使用テンプレート** | Relation     | NO   | 警告/リマインド送信時に使用したテンプレートページ。                                   | -                                                                                                 |
+| **対象条文**         | Relation     | NO   | 条文マスタDBへのリレーション。                                                       | -                                                                                                 |
 
 ---
 
@@ -61,10 +44,24 @@ Slack監視Botが違反投稿を記録・管理するためのNotionデータベ
 
 ### ステータス値の統一
 
-プロパティ名（キー）は日本語ですが、**対応ステータスの選択肢（値）は英語**（`Unprocessed`, `Approved`, `Dismissed`）で統一して運用します。
-これに伴い、Lambda側のコード（`common/notion_client.py`, `app_alert/handler.py`）内のステータス文字列定数を修正する必要があります。
+プロパティ名（キー）は日本語ですが、**対応ステータスの選択肢（値）は英語**（`Unprocessed`, `Approved`, `Dismissed`, `48h_Over`, `Remind_Requested`, `Reminded`）で統一して運用します。
+
+### ステータス遷移
+
+```
+Unprocessed → Approved → 48h_Over → Remind_Requested → Reminded
+           ↘ Dismissed
+```
+
+| 遷移 | トリガー | Lambda |
+|------|---------|--------|
+| Unprocessed → Approved | 管理者がApproveボタン押下 | B |
+| Unprocessed → Dismissed | 管理者がDismissボタン押下 | B |
+| Approved → Approved (警告送信日時記録) | 初回警告送信（Notion手動Approve時） | D |
+| Approved → 48h_Over | 警告送信から48h経過 | D |
+| 48h_Over → Remind_Requested | 運営がNotionで手動変更 | (手動) |
+| Remind_Requested → Reminded | 削除リマインド送信完了 | D |
 
 ### オプショナル項目
 
-`信頼度` および `該当条文` は、Lambda A (app_inspect) の判定ロジック修正により値が供給されることを前提としています。
 `信頼度` および `該当条文` は、Lambda A (app_inspect) の判定ロジック修正により値が供給されることを前提としています。

--- a/infra/stacks/infra_stack.py
+++ b/infra/stacks/infra_stack.py
@@ -8,6 +8,8 @@ from aws_cdk import (
     aws_ssm as ssm,
     aws_logs as logs,
     aws_iam as iam,
+    aws_events as events,
+    aws_events_targets as targets,
 )
 from constructs import Construct
 
@@ -79,6 +81,38 @@ class InfraStack(Stack):
             "NotionDbId",
             type="String",
             description="Notion Database ID to store violation logs.",
+        )
+
+        slack_bot_token_param_name = CfnParameter(
+            self,
+            "SlackBotTokenParamName",
+            type="String",
+            default="/slack/bot/token",
+            description="SSM Parameter name for Slack Bot Token (SecureString). Used by Lambda D.",
+        )
+
+        notion_template_db_id = CfnParameter(
+            self,
+            "NotionTemplateDbId",
+            type="String",
+            default="",
+            description="Notion Database ID for warning/reminder templates.",
+        )
+
+        reminder_hours_threshold = CfnParameter(
+            self,
+            "ReminderHoursThreshold",
+            type="Number",
+            default=48,
+            description="Hours after warning before marking as 48h_Over.",
+        )
+
+        remind_schedule_minutes = CfnParameter(
+            self,
+            "RemindScheduleMinutes",
+            type="Number",
+            default=5,
+            description="EventBridge schedule interval in minutes for Lambda D.",
         )
 
         # -----------------------------
@@ -170,7 +204,44 @@ class InfraStack(Stack):
         )
 
         # -----------------------------
-        # 5. IAM権限付与 (SSM Parameter Store)
+        # 6. Lambda D: リマインド定期実行 (app_remind)
+        # -----------------------------
+        lambda_d = _lambda.DockerImageFunction(
+            self,
+            "LambdaD_AppRemind",
+            code=_lambda.DockerImageCode.from_image_asset(
+                directory="../lambda/",
+                exclude=["app_inspect", "app_alert", "app_oauth"],
+            ),
+            timeout=Duration.seconds(60),
+            memory_size=512,
+            log_retention=logs.RetentionDays.ONE_WEEK,
+            environment={
+                "SLACK_BOT_TOKEN_PARAM_NAME": slack_bot_token_param_name.value_as_string,
+                "NOTION_API_KEY_PARAM_NAME": notion_api_key_param_name.value_as_string,
+                "NOTION_DB_ID": notion_db_id.value_as_string,
+                "NOTION_TEMPLATE_DB_ID": notion_template_db_id.value_as_string,
+                "REMINDER_HOURS_THRESHOLD": reminder_hours_threshold.value_as_string,
+            },
+        )
+        lambda_d.node.default_child.add_property_override(
+            "ImageConfig",
+            {"Command": ["app_remind.handler.lambda_handler"]}
+        )
+
+        # EventBridge定期実行ルール
+        remind_rule = events.Rule(
+            self,
+            "RemindScheduleRule",
+            schedule=events.Schedule.rate(
+                Duration.minutes(remind_schedule_minutes.value_as_number)
+            ),
+            description="Trigger Lambda D (app_remind) periodically",
+        )
+        remind_rule.add_target(targets.LambdaFunction(lambda_d))
+
+        # -----------------------------
+        # 7. IAM権限付与 (SSM Parameter Store)
         # -----------------------------
         # TODO: 最小権限の原則に基づき、必要なパラメータARNのみを許可するように改善
         runtime_policy = iam.PolicyStatement(
@@ -184,7 +255,8 @@ class InfraStack(Stack):
 
         lambda_a.add_to_role_policy(runtime_policy)
         lambda_b.add_to_role_policy(runtime_policy)
-        
+        lambda_d.add_to_role_policy(runtime_policy)
+
         oauth_policy = iam.PolicyStatement(
             actions=["ssm:GetParameter","ssm:PutParameter"],
             resources=[
@@ -211,13 +283,13 @@ class InfraStack(Stack):
         )
 
         slack_root = api.root.add_resource("slack")
-        events = slack_root.add_resource("events")
+        events_resource = slack_root.add_resource("events")
         interactions = slack_root.add_resource("interactions")
         oauth = slack_root.add_resource("oauth")
         callback = oauth.add_resource("callback")
 
         # POST /slack/events -> Lambda A
-        events.add_method(
+        events_resource.add_method(
             "POST",
             apigw.LambdaIntegration(lambda_a, proxy=True),
         )


### PR DESCRIPTION
infra_stack.py: Lambda D定義、EventBridge定期実行ルール、IAM権限付与
notion_db_schema.md: ステータス遷移(48h_Over/Remind_Requested/Reminded)追加