### PR TITLE
fix: /admin/oauth-allowlist の認証をIAM(SigV4)に切り替え

### DIFF
--- a/infra/stacks/infra_stack.py
+++ b/infra/stacks/infra_stack.py
@@ -179,7 +179,7 @@ class InfraStack(Stack):
             "LambdaA_AppInspect",
             code=_lambda.DockerImageCode.from_image_asset(
                 directory="../lambda/",
-                exclude=["app_alert", "app_oauth", "app_remind", "app_batch"],
+                exclude=["app_alert", "app_oauth", "app_remind", "app_batch", "app_admin"],
             ),
             timeout=Duration.seconds(30),
             memory_size=512,
@@ -213,7 +213,7 @@ class InfraStack(Stack):
             "LambdaB_AppAlert",
             code=_lambda.DockerImageCode.from_image_asset(
                 directory="../lambda/",
-                exclude=["app_inspect", "app_oauth", "app_remind", "app_batch"],
+                exclude=["app_inspect", "app_oauth", "app_remind", "app_batch", "app_admin"],
             ),
             timeout=Duration.seconds(30),
             memory_size=512,
@@ -241,7 +241,7 @@ class InfraStack(Stack):
             "LambdaC_SlackOAuth",
             code=_lambda.DockerImageCode.from_image_asset(
                 directory="../lambda/",
-                exclude=["app_inspect", "app_alert", "app_remind", "app_batch"],
+                exclude=["app_inspect", "app_alert", "app_remind", "app_batch", "app_admin"],
             ),
             timeout=Duration.seconds(30),
             memory_size=512,
@@ -269,7 +269,7 @@ class InfraStack(Stack):
             "LambdaD_AppRemind",
             code=_lambda.DockerImageCode.from_image_asset(
                 directory="../lambda/",
-                exclude=["app_inspect", "app_alert", "app_oauth", "app_batch"],
+                exclude=["app_inspect", "app_alert", "app_oauth", "app_batch", "app_admin"],
             ),
             timeout=Duration.seconds(60),
             memory_size=512,
@@ -308,7 +308,7 @@ class InfraStack(Stack):
             "LambdaE_AppBatch",
             code=_lambda.DockerImageCode.from_image_asset(
                 directory="../lambda/",
-                exclude=["app_alert", "app_oauth", "app_remind"],
+                exclude=["app_alert", "app_oauth", "app_remind", "app_admin"],
             ),
             timeout=Duration.seconds(900),
             memory_size=1024,
@@ -328,6 +328,29 @@ class InfraStack(Stack):
         lambda_e.node.default_child.add_property_override(
             "ImageConfig",
             {"Command": ["app_batch.handler.lambda_handler"]},
+        )
+
+        # -----------------------------
+        # 6.6 Lambda F: OAuth許可リスト管理 (app_admin)
+        # -----------------------------
+        lambda_f = _lambda.DockerImageFunction(
+            self,
+            "LambdaF_AppAdmin",
+            code=_lambda.DockerImageCode.from_image_asset(
+                directory="../lambda/",
+                exclude=["app_inspect", "app_alert", "app_oauth", "app_remind", "app_batch"],
+            ),
+            timeout=Duration.seconds(30),
+            memory_size=512,
+            log_retention=logs.RetentionDays.ONE_WEEK,
+            environment={
+                "OAUTH_ALLOWED_TEAM_IDS_PARAM_NAME": oauth_allowed_team_ids_param_name.value_as_string,
+            },
+        )
+
+        lambda_f.node.default_child.add_property_override(
+            "ImageConfig",
+            {"Command": ["app_admin.handler.lambda_handler"]},
         )
 
         # -----------------------------
@@ -366,6 +389,26 @@ class InfraStack(Stack):
         )
         lambda_c.add_to_role_policy(oauth_policy)
 
+        # app_admin: 許可リストのSSMパラメータ1個だけに限定した最小スコープ
+        admin_policy = iam.PolicyStatement(
+            actions=["ssm:GetParameter", "ssm:PutParameter"],
+            resources=[
+                get_param_arn(oauth_allowed_team_ids_param_name.value_as_string),
+            ],
+        )
+        lambda_f.add_to_role_policy(admin_policy)
+
+        # /admin/oauth-allowlist を呼び出すための専用IAMロール。
+        # x-api-key はAWS公式にも「認証・認可には使わない」ことが明記されているため
+        # (usage planはrate limiting/利用者識別用の仕組みでしかない)、
+        # IAM(SigV4)で呼び出し元を限定する。実際に呼び出す人/システムはこのロールをAssumeする。
+        admin_caller_role = iam.Role(
+            self,
+            "OAuthAllowlistAdminCallerRole",
+            assumed_by=iam.AccountPrincipal(self.account),
+            description="Assume this role (SigV4) to call POST /admin/oauth-allowlist",
+        )
+
         # -----------------------------
         # 8. API Gateway (Slack エンドポイント)
         # -----------------------------
@@ -380,6 +423,12 @@ class InfraStack(Stack):
                 metrics_enabled=True,
                 throttling_rate_limit=50,
                 throttling_burst_limit=100,
+                method_options={
+                    "/admin/oauth-allowlist/POST": apigw.MethodDeploymentOptions(
+                        throttling_rate_limit=1,
+                        throttling_burst_limit=5,
+                    ),
+                },
             ),
         )
 
@@ -389,6 +438,9 @@ class InfraStack(Stack):
         oauth = slack_root.add_resource("oauth")
         start = oauth.add_resource("start")
         callback = oauth.add_resource("callback")
+
+        admin = api.root.add_resource("admin")
+        oauth_allowlist = admin.add_resource("oauth-allowlist")
 
         # POST /slack/events -> Lambda A
         events_resource.add_method(
@@ -412,6 +464,23 @@ class InfraStack(Stack):
         callback.add_method(
             "GET",
             apigw.LambdaIntegration(lambda_c, proxy=True),
+        )
+
+        # POST /admin/oauth-allowlist -> Lambda F
+        # x-api-keyは「認証・認可の手段として使うべきではない」とAWS公式ドキュメントが
+        # 明記しているため(usage plan/api keyは利用量トラッキング用途のみ)、
+        # IAM(SigV4)で呼び出し元をadmin_caller_roleに限定する。
+        oauth_allowlist_method = oauth_allowlist.add_method(
+            "POST",
+            apigw.LambdaIntegration(lambda_f, proxy=True),
+            authorization_type=apigw.AuthorizationType.IAM,
+        )
+
+        admin_caller_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["execute-api:Invoke"],
+                resources=[oauth_allowlist_method.method_arn],
+            )
         )
 
         # -----------------------------
@@ -443,4 +512,18 @@ class InfraStack(Stack):
             "SlackOAuthRedirectUrl",
             value=f"{api.url}slack/oauth/callback",
             description="Redirect URL for Slack OAuth callback",
+        )
+
+        CfnOutput(
+            self,
+            "OAuthAllowlistAdminUrl",
+            value=f"{api.url}admin/oauth-allowlist",
+            description="URL for admin allowlist registration (requires SigV4 request signed as OAuthAllowlistAdminCallerRole)",
+        )
+
+        CfnOutput(
+            self,
+            "OAuthAllowlistAdminCallerRoleArn",
+            value=admin_caller_role.role_arn,
+            description="IAM role to assume (sts:AssumeRole) before calling /admin/oauth-allowlist with SigV4",
         )

--- a/lambda/app_admin/handler.py
+++ b/lambda/app_admin/handler.py
@@ -1,0 +1,54 @@
+import json
+import os
+import re
+from typing import Any
+
+from common.secret_manager import get_parameter_by_name_no_cache, put_secure_parameter
+from common.observability import build_context, log_info, log_error
+
+SERVICE = "app_admin"
+
+TEAM_ID_PATTERN = re.compile(r"^T[A-Z0-9]{8,}$")
+
+
+def _response(status_code: int, body: dict) -> dict:
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _add_team_to_allowlist(team_id: str) -> str:
+    """許可リストに team_id を追加する。戻り値は added / duplicate"""
+    param_name = os.environ["OAUTH_ALLOWED_TEAM_IDS_PARAM_NAME"]
+    current_value = get_parameter_by_name_no_cache(param_name)
+    current_ids = {x.strip() for x in current_value.split(",") if x.strip()}
+
+    if team_id in current_ids:
+        return "duplicate"
+
+    new_ids = sorted(current_ids | {team_id})
+    put_secure_parameter(param_name, ",".join(new_ids))
+    return "added"
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict:
+    ctx = build_context(event, context, service=SERVICE)
+    log_info(ctx, action="admin_request_received")
+
+    try:
+        body = json.loads(event.get("body") or "{}")
+        team_id = str(body.get("team_id") or "").strip()
+
+        if not TEAM_ID_PATTERN.match(team_id):
+            log_info(ctx, action="admin_invalid_team_id", team_id=team_id)
+            return _response(200, {"result": "invalid", "team_id": team_id})
+
+        result = _add_team_to_allowlist(team_id)
+        log_info(ctx, action="admin_allowlist_updated", team_id=team_id, result=result)
+        return _response(200, {"result": result, "team_id": team_id})
+
+    except Exception as e:
+        log_error(ctx, action="admin_request_failed", error=e)
+        return _response(500, {"result": "error"})

--- a/tests/unit/test_app_admin.py
+++ b/tests/unit/test_app_admin.py
@@ -1,0 +1,99 @@
+# tests/unit/test_app_admin.py
+
+import json
+
+import pytest
+
+import app_admin.handler as admin
+
+
+@pytest.fixture
+def admin_common_mocks(monkeypatch):
+    """app_admin.handler の外部依存を最小限モックする"""
+    put_calls = []
+
+    monkeypatch.setattr(admin, "build_context", lambda *args, **kwargs: {})
+    monkeypatch.setattr(admin, "log_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(admin, "log_error", lambda *args, **kwargs: None)
+
+    monkeypatch.setattr(
+        admin,
+        "put_secure_parameter",
+        lambda name, value, *args, **kwargs: put_calls.append((name, value)),
+    )
+
+    monkeypatch.setenv("OAUTH_ALLOWED_TEAM_IDS_PARAM_NAME", "/slack/oauth/allowed_team_ids")
+
+    return {"put_calls": put_calls}
+
+
+def _event(team_id: str) -> dict:
+    return {"body": json.dumps({"team_id": team_id})}
+
+
+def test_adds_new_team_id(monkeypatch, admin_common_mocks):
+    """未登録のteam_idは許可リストへ追加され、addedが返ること"""
+    monkeypatch.setattr(admin, "get_parameter_by_name_no_cache", lambda name: "T111,T222")
+
+    resp = admin.lambda_handler(_event("T333AAAAA"), {})
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"result": "added", "team_id": "T333AAAAA"}
+    assert admin_common_mocks["put_calls"] == [
+        ("/slack/oauth/allowed_team_ids", "T111,T222,T333AAAAA"),
+    ]
+
+
+def test_duplicate_team_id_is_skipped(monkeypatch, admin_common_mocks):
+    """既に許可リストにあるteam_idはduplicateを返し、書き込みは行わないこと"""
+    monkeypatch.setattr(admin, "get_parameter_by_name_no_cache", lambda name: "T111,T222AAAAA")
+
+    resp = admin.lambda_handler(_event("T222AAAAA"), {})
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"result": "duplicate", "team_id": "T222AAAAA"}
+    assert admin_common_mocks["put_calls"] == []
+
+
+@pytest.mark.parametrize("team_id", ["", "invalid", "t111aaaaa", "T111"])
+def test_invalid_team_id_format_is_rejected(monkeypatch, admin_common_mocks, team_id):
+    """形式不正なteam_idはinvalidを返し、SSMへは触れないこと"""
+    called = {"count": 0}
+    monkeypatch.setattr(
+        admin,
+        "get_parameter_by_name_no_cache",
+        lambda name: called.__setitem__("count", called["count"] + 1) or "",
+    )
+
+    resp = admin.lambda_handler(_event(team_id), {})
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"result": "invalid", "team_id": team_id}
+    assert called["count"] == 0
+    assert admin_common_mocks["put_calls"] == []
+
+
+def test_missing_body_is_treated_as_invalid(admin_common_mocks):
+    """bodyが無いリクエストはinvalidとして扱われること"""
+    resp = admin.lambda_handler({}, {})
+
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"result": "invalid", "team_id": ""}
+
+
+def test_unexpected_error_returns_500(monkeypatch, admin_common_mocks):
+    """SSM呼び出しで例外が発生した場合は500を返すこと"""
+    def _raise(name):
+        raise RuntimeError("ssm boom")
+
+    monkeypatch.setattr(admin, "get_parameter_by_name_no_cache", _raise)
+
+    resp = admin.lambda_handler(_event("T333AAAAA"), {})
+
+    assert resp["statusCode"] == 500
+    body = json.loads(resp["body"])
+    assert body == {"result": "error"}


### PR DESCRIPTION
app_admin (OAuth許可リスト追加API) をCDKスタックに組み込む。AWS公式ドキュメントが 「API keyは認証・認可の手段として使うべきではない」と明記しているため、
x-api-key + usage planではなくAPI GatewayのIAM認証(AuthorizationType.IAM)を採用し、 専用のOAuthAllowlistAdminCallerRoleにexecute-api:Invokeを限定付与する。

## 概要
<!-- このプルリクエストの概要と目的を簡潔に説明してください。 -->

## 変更内容
<!-- どのような変更を行ったかを記載してください。 -->
- 変更点1
- 変更点2
- 変更点3

## 影響範囲
<!-- この変更が他の部分に影響を与える可能性があるかを記載してください。 -->
- 影響箇所1
- 影響箇所2
- 影響箇所3

## テスト
<!-- 変更が正しく動作することを確認するための動作手順と動作結果を説明してください。 -->
- 動作手順：
- 動作結果：
