### PR TITLE
Fix/logs

### DIFF
--- a/infra/stacks/infra_stack.py
+++ b/infra/stacks/infra_stack.py
@@ -409,6 +409,22 @@ class InfraStack(Stack):
             description="Assume this role (SigV4) to call POST /admin/oauth-allowlist",
         )
 
+        # GAS(Google Apps Script)はAssumeRoleを自前で実行できず、SigV4署名を
+        # 計算するには長期のAccessKey/SecretKeyが必要になる。
+        # そのためGAS専用のIAMユーザーを用意し、execute-api:Invokeをこの
+        # APIメソッド1つに限定する。SecretAccessKeyはCfnOutputに出さず、
+        # 払い出し直後にAWSコンソール/CLIで一度だけ確認してGASのScript
+        # Propertiesへ転記する運用とする(コードやOutputに平文で残さない)。
+        gas_caller_user = iam.User(
+            self,
+            "OAuthAllowlistGasCallerUser",
+        )
+        gas_caller_access_key = iam.CfnAccessKey(
+            self,
+            "OAuthAllowlistGasCallerAccessKey",
+            user_name=gas_caller_user.user_name,
+        )
+
         # -----------------------------
         # 8. API Gateway (Slack エンドポイント)
         # -----------------------------
@@ -483,6 +499,13 @@ class InfraStack(Stack):
             )
         )
 
+        gas_caller_user.add_to_policy(
+            iam.PolicyStatement(
+                actions=["execute-api:Invoke"],
+                resources=[oauth_allowlist_method.method_arn],
+            )
+        )
+
         # -----------------------------
         # 9. Outputs
         # -----------------------------
@@ -526,4 +549,16 @@ class InfraStack(Stack):
             "OAuthAllowlistAdminCallerRoleArn",
             value=admin_caller_role.role_arn,
             description="IAM role to assume (sts:AssumeRole) before calling /admin/oauth-allowlist with SigV4",
+        )
+
+        # SecretAccessKeyはCfnOutputに出さない(スタック情報に平文で残ってしまうため)。
+        # AccessKeyIdだけを出力し、SecretAccessKeyはデプロイ直後にAWSコンソール/CLIで
+        # 一度だけ確認してGASのScript Propertiesへ手動転記する。
+        CfnOutput(
+            self,
+            "OAuthAllowlistGasCallerAccessKeyId",
+            value=gas_caller_access_key.ref,
+            description="AccessKeyId for GAS to call /admin/oauth-allowlist with SigV4. "
+                         "SecretAccessKey is intentionally not output here; retrieve it once "
+                         "from the AWS Console/CLI right after deploy.",
         )

--- a/lambda/app_admin/handler.py
+++ b/lambda/app_admin/handler.py
@@ -20,17 +20,20 @@ def _response(status_code: int, body: dict) -> dict:
 
 
 def _add_team_to_allowlist(team_id: str) -> str:
-    """許可リストに team_id を追加する。戻り値は added / duplicate"""
+    """許可リストに team_id を追加する。戻り値は added / duplicate
+
+    重複時にearly returnして書き込みを省略すると、SSMへの反映有無が
+    申請者からは見えず「登録されたはずが実は反映されていない」不安につながる。
+    そのため重複でも常にPutParameterを実行し、申請の都度リストを書き戻す。
+    """
     param_name = os.environ["OAUTH_ALLOWED_TEAM_IDS_PARAM_NAME"]
     current_value = get_parameter_by_name_no_cache(param_name)
     current_ids = {x.strip() for x in current_value.split(",") if x.strip()}
 
-    if team_id in current_ids:
-        return "duplicate"
-
+    result = "duplicate" if team_id in current_ids else "added"
     new_ids = sorted(current_ids | {team_id})
     put_secure_parameter(param_name, ",".join(new_ids))
-    return "added"
+    return result
 
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict:

--- a/tests/unit/test_app_admin.py
+++ b/tests/unit/test_app_admin.py
@@ -45,8 +45,12 @@ def test_adds_new_team_id(monkeypatch, admin_common_mocks):
     ]
 
 
-def test_duplicate_team_id_is_skipped(monkeypatch, admin_common_mocks):
-    """既に許可リストにあるteam_idはduplicateを返し、書き込みは行わないこと"""
+def test_duplicate_team_id_still_writes(monkeypatch, admin_common_mocks):
+    """既に許可リストにあるteam_idはduplicateを返すが、SSMへの書き込みは常に実行すること
+
+    申請者からは「登録されたはずが実は反映されていない」状態が見えないようにするため、
+    重複判定はレスポンスの result にのみ反映し、書き込み自体は省略しない。
+    """
     monkeypatch.setattr(admin, "get_parameter_by_name_no_cache", lambda name: "T111,T222AAAAA")
 
     resp = admin.lambda_handler(_event("T222AAAAA"), {})
@@ -54,7 +58,9 @@ def test_duplicate_team_id_is_skipped(monkeypatch, admin_common_mocks):
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert body == {"result": "duplicate", "team_id": "T222AAAAA"}
-    assert admin_common_mocks["put_calls"] == []
+    assert admin_common_mocks["put_calls"] == [
+        ("/slack/oauth/allowed_team_ids", "T111,T222AAAAA"),
+    ]
 
 
 @pytest.mark.parametrize("team_id", ["", "invalid", "t111aaaaa", "T111"])


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの概要と目的を簡潔に説明してください。 -->
/admin/oauth-allowlist の IAM(SigV4) 化に伴う後続対応。GAS(Google Apps Script) からの呼び出し経路を確保するための専用 IAM ユーザー追加と、app_admin の重複登録時の挙動修正を行う。

## 変更内容
<!-- どのような変更を行ったかを記載してください。 -->
- GAS呼び出し用の専用IAMユーザーを新規作成（infra/stacks/infra_stack.py）: /admin/oauth-allowlist を x-api-key から IAM(SigV4) 認証に切り替えたことで、GAS は sts:AssumeRole を自前実行できず呼び出し手段を失っていたため、execute-api:Invoke をこのAPIメソッド1つに限定した専用IAMユーザー（OAuthAllowlistGasCallerUser）と長期AccessKey（OAuthAllowlistGasCallerAccessKey）を追加した
- SecretAccessKeyをCfnOutputに出さない設計: AccessKeyIdのみをCfnOutput(OAuthAllowlistGasCallerAccessKeyId)として出力し、SecretAccessKeyはデプロイ直後にコンソール/CLIで一度だけ取得してGAS側のScript Propertiesへ手動転記する運用にした（スタック情報に平文のシークレットを残さないため）
- app_adminの重複登録時にもSSM書き込みを常に実行するよう修正: 従来はteam_idが既に許可リストに存在する場合、早期リターンしてSSMへのPutParameterをスキップしていたが、これだと申請者から見て「登録されたはずが実際には反映されているか分からない」状態になる。重複でも常にPutParameterを実行し、申請の都度リストを書き戻すよう変更した（レスポンスのresultはadded/duplicateのまま維持し、監査用の区別は残す）


## 影響範囲
<!-- この変更が他の部分に影響を与える可能性があるかを記載してください。 -->
- infra/stacks/infra_stack.py: IAMリソース（ユーザー・AccessKey・ポリシー）とCfnOutputの追加のみで、既存のAPI Gatewayやその他Lambdaのリソース定義には影響しない
- lambda/app_admin/handler.py: _add_team_to_allowlistの内部制御フローのみの変更。レスポンスのJSON形式（{"result": ..., "team_id": ...}）に変更はなく、呼び出し側（GAS）への影響はない
- GAS側の呼び出しコード: 本PRのマージ・デプロイ後、発行されるOAuthAllowlistGasCallerAccessKeyIdとデプロイ直後に取得するSecretAccessKeyをGASのScript Propertiesに設定する追加作業が必要（Notion設計ドキューメント側で手順を管理）

## テスト
<!-- 変更が正しく動作することを確認するための動作手順と動作結果を説明してください。 -->
- 動作手順：pytest tests/unit/test_app_admin.py を実行
- 動作結果：全8件成功。特に test_duplicate_team_id_still_writes で、重複判定時も put_secure_parameter が実際に呼ばれ、SSMへの書き込みが省略されないことを確認済み
- 動作手順：cdk synth（infra/ディレクトリ）を実行
- 動作結果：OAuthAllowlistGasCallerUser・OAuthAllowlistGasCallerAccessKey・execute-api:Invokeポリシーがテンプレートに含まれ、構文エラーなく合成できることを確認済み
