### PR TITLE
fix: app_adminの重複登録を再びスキップする挙動に戻す

### DIFF
--- a/lambda/app_admin/handler.py
+++ b/lambda/app_admin/handler.py
@@ -20,20 +20,17 @@ def _response(status_code: int, body: dict) -> dict:
 
 
 def _add_team_to_allowlist(team_id: str) -> str:
-    """許可リストに team_id を追加する。戻り値は added / duplicate
-
-    重複時にearly returnして書き込みを省略すると、SSMへの反映有無が
-    申請者からは見えず「登録されたはずが実は反映されていない」不安につながる。
-    そのため重複でも常にPutParameterを実行し、申請の都度リストを書き戻す。
-    """
+    """許可リストに team_id を追加する。戻り値は added / duplicate"""
     param_name = os.environ["OAUTH_ALLOWED_TEAM_IDS_PARAM_NAME"]
     current_value = get_parameter_by_name_no_cache(param_name)
     current_ids = {x.strip() for x in current_value.split(",") if x.strip()}
 
-    result = "duplicate" if team_id in current_ids else "added"
+    if team_id in current_ids:
+        return "duplicate"
+
     new_ids = sorted(current_ids | {team_id})
     put_secure_parameter(param_name, ",".join(new_ids))
-    return result
+    return "added"
 
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict:

--- a/tests/unit/test_app_admin.py
+++ b/tests/unit/test_app_admin.py
@@ -45,12 +45,8 @@ def test_adds_new_team_id(monkeypatch, admin_common_mocks):
     ]
 
 
-def test_duplicate_team_id_still_writes(monkeypatch, admin_common_mocks):
-    """既に許可リストにあるteam_idはduplicateを返すが、SSMへの書き込みは常に実行すること
-
-    申請者からは「登録されたはずが実は反映されていない」状態が見えないようにするため、
-    重複判定はレスポンスの result にのみ反映し、書き込み自体は省略しない。
-    """
+def test_duplicate_team_id_is_skipped(monkeypatch, admin_common_mocks):
+    """既に許可リストにあるteam_idはduplicateを返し、SSMへの書き込みは省略すること"""
     monkeypatch.setattr(admin, "get_parameter_by_name_no_cache", lambda name: "T111,T222AAAAA")
 
     resp = admin.lambda_handler(_event("T222AAAAA"), {})
@@ -58,9 +54,7 @@ def test_duplicate_team_id_still_writes(monkeypatch, admin_common_mocks):
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert body == {"result": "duplicate", "team_id": "T222AAAAA"}
-    assert admin_common_mocks["put_calls"] == [
-        ("/slack/oauth/allowed_team_ids", "T111,T222AAAAA"),
-    ]
+    assert admin_common_mocks["put_calls"] == []
 
 
 @pytest.mark.parametrize("team_id", ["", "invalid", "t111aaaaa", "T111"])


### PR DESCRIPTION
重複時も常にPutParameterを実行する方式(8006fa2)を一度採用したが、
運用上は「重複ならSSMへの書き込み自体を行わない」挙動が望ましいとの
判断により、早期リターンでスキップする実装に戻す。

## 概要
<!-- このプルリクエストの概要と目的を簡潔に説明してください。 -->

## 変更内容
<!-- どのような変更を行ったかを記載してください。 -->
- 変更点1
- 変更点2
- 変更点3

## 影響範囲
<!-- この変更が他の部分に影響を与える可能性があるかを記載してください。 -->
- 影響箇所1
- 影響箇所2
- 影響箇所3

## テスト
<!-- 変更が正しく動作することを確認するための動作手順と動作結果を説明してください。 -->
- 動作手順：
- 動作結果：
